### PR TITLE
fix: Re-work the Telemetry ping.  🎧

### DIFF
--- a/main.js
+++ b/main.js
@@ -106,17 +106,6 @@ function initWindow(window) {
   }
 }
 
-function sendPayload() {
-  for (let window of browserWindows) {
-    let win = viewFor(window);
-    if (win.VerticalTabs) {
-      utils.addPingStats(win.VerticalTabs.stats);
-    }
-  }
-  utils.setPayload('tab_center_tabs_on_top', prefs.prefs.opentabstop);
-  utils.sendPing();
-}
-
 function largeTabsChange() {
   for (let window of browserWindows) {
     let win = viewFor(window);
@@ -190,16 +179,9 @@ exports.main = function (options, callbacks) {
       }
     }
   });
-
-
-  setInterval(sendPayload, 24 * 60 * 60 * 1000);  // Every 24h.
-  //setInterval(sendPayload, 20*1000);  // Every 20s for debugging.
 };
 
 exports.onUnload = function (reason) {
-  // Send out the ping
-  sendPayload();
-
   // If the app is shutting down, skip the rest
   if (reason === 'shutdown') {
     return;


### PR DESCRIPTION
Don't send the ping on shutdown, or every 24 hours, but instead send one per-event.

@clouserw Two questions…

1. I'm sending the `tab_center_tabs_on_top` and (new) `tab_center_show_thumbnails` prefs on every ping.  Does that seem reasonable to you?  Should we only send them sometimes?
1. Should we add a little more telemetry to see how often people use the search bar and how often people see the thumbnails (vs. just the favicons)?

Reviewer: @chuckharmiston
