### PR TITLE
fix: hide private browsing icon :mask:

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -103,8 +103,9 @@
 }*/
 
 /* hide private browsing indicator in the vertical tab box */
-#verticaltabs-box .private-browsing-indicator {
-  display: none;
+#verticaltabs-box .private-browsing-indicator,
+#verticaltabs-box #private-browsing-indicator {
+  display: none !important;
 }
 
 #TabsToolbar[brighttext] .tabs-newtab-button,


### PR DESCRIPTION
r: @bwinton 

- hide private browsing indicator when inside of the #verticaltabs-box, for now.

fixes: #502. (sort-of)

note: private browsing indicator is still visible on mac as it is not located inside of #verticaltabs-box. But it looks good in the top right corner of the #titlebar