### PR TITLE
fix: Run the initialization code for _all_ the new windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint . --ext=js,jsm vertical-tabbrowser.xml && stylelint \"**/*.css\""
   },
   "permissions": {
+    "multiprocess": true,
     "private-browsing": true
   },
   "repository": {

--- a/skin/base.css
+++ b/skin/base.css
@@ -333,14 +333,12 @@
 }
 
 #sidebar-box,
-#sidebar-box[hidden="true"] ~ #appcontent,
-#sidebar-box[hidden="true"] ~ #PopupAutoCompleteRichResult {
+#sidebar-box[hidden="true"] ~ #appcontent {
   margin-left: var(--collapsed-width);
 }
 
 #main-window[tabspinned="true"] #sidebar-box,
-#main-window[tabspinned="true"] #sidebar-box[hidden="true"] ~ #appcontent,
-#main-window[tabspinned="true"] #sidebar-box[hidden="true"] ~ #PopupAutoCompleteRichResult {
+#main-window[tabspinned="true"] #sidebar-box[hidden="true"] ~ #appcontent {
   margin-left: 0;
 }
 
@@ -349,8 +347,7 @@
   margin-left: 0;
 }
 
-#main-window[inFullscreen][inDOMFullscreen] #appcontent,
-#main-window[inFullscreen][inDOMFullscreen] #PopupAutoCompleteRichResult {
+#main-window[inFullscreen][inDOMFullscreen] #appcontent {
   margin-left: 0 !important;
 }
 
@@ -358,10 +355,6 @@
 .browserContainer,
 #PopupAutoCompleteRichResult {
   width: calc(100vw - var(--collapsed-width));
-}
-
-#PopupAutoCompleteRichResult {
-  margin-left: -32px !important;
 }
 
 #main-window[tabspinned="true"] #verticaltabs-box + #appcontent #navigator-toolbox,

--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -598,6 +598,10 @@
       <method name="refreshThumbAndLabel">
         <body><![CDATA[
           /* global VerticalTabs:false, PageThumbs:false */
+          if (!this.linkedBrowser) {
+            // too soon.  Bail.
+            return;
+          }
           let uri = VerticalTabs.getUri(this);
           let url = uri.spec;
           const canvas = document.getAnonymousElementByAttribute(this, 'anonid', 'tab-meta-image');

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -253,6 +253,30 @@ VerticalTabs.prototype = {
     contentbox.appendChild(bottom);
     let top = document.getElementById('navigator-toolbox');
     let browserPanel = document.getElementById('browser-panel');
+    let autocomplete = document.getElementById('PopupAutoCompleteRichResult');
+    let autocompleteOpen = autocomplete._openAutocompletePopup;
+    autocomplete._openAutocompletePopup = (aInput, aElement) => {
+      autocompleteOpen.bind(autocomplete)(aInput, aElement);
+      let rect = window.document.documentElement.getBoundingClientRect();
+      let popupDirection = autocomplete.style.direction;
+
+      // Make the popup's starting margin negative so that the leading edge
+      // of the popup aligns with the window border.
+      let elementRect = aElement.getBoundingClientRect();
+      if (popupDirection === 'rtl') {
+        let offset = elementRect.right - rect.right;
+        autocomplete.style.marginRight = offset + 'px';
+      } else {
+        let offset = rect.left - elementRect.left;
+        if (mainWindow.getAttribute('tabspinned') !== 'true') {
+          offset += 45;
+        } else {
+          offset += this.pinnedWidth;
+        }
+        autocomplete.style.marginLeft = offset + 'px';
+      }
+    };
+
 
     // save the label of the first tab, and the toolbox palette for later…
     let tabs = document.getElementById('tabbrowser-tabs');
@@ -460,6 +484,8 @@ VerticalTabs.prototype = {
     });
 
     this.unloaders.push(function () {
+      autocomplete._openAutocompletePopup = autocompleteOpen;
+
       // Move the tabs toolbar back to where it was
       toolbar._toolbox = null; // reset value set by constructor
       toolbar.removeAttribute('toolboxid');

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -710,7 +710,11 @@ VerticalTabs.prototype = {
   },
 };
 
-exports.addVerticalTabs = (win, data) => new VerticalTabs(win, data);
+exports.addVerticalTabs = (win, data) => {
+  if (!win.VerticalTabs) {
+    new VerticalTabs(win, data);
+  }
+};
 
 //use to set preview image as metadata image 4/4
 // XPCOMUtils.defineLazyModuleGetter(VerticalTabs.prototype, "PageMetadata", "resource://gre/modules/PageMetadata.jsm");


### PR DESCRIPTION
Bail on updating stuff if we don't have a linkedBrowser yet.
Don't add two VerticalTabs instances to a window.
Watch for the `domwindowopened` event to catch all opening windows.
Mark the add-on as multiprocess-compatible.

Reviewer: @ericawright
Fixes #529.