### PR TITLE
Fix:Rebuild newtab button

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -319,8 +319,7 @@ VerticalTabs.prototype = {
     //if new tab button is not in toolbar, find it and insert it.
     if (!toolbar.querySelector('#new-tab-button')) {
       //save position of button for restoring later
-      let NewTabButton = document.getElementById('new-tab-button') || CustomizableUI.getWidget('new-tab-button').forWindow(this.window).node;
-
+      let NewTabButton = CustomizableUI.getWidget('new-tab-button').forWindow(this.window).node;
       let NewTabButtonParent = NewTabButton.parentNode;
       let NewTabButtonSibling = NewTabButton.nextSibling;
       toolbar.insertBefore(NewTabButton, toolbar.firstChild);
@@ -446,10 +445,15 @@ VerticalTabs.prototype = {
     let previous_close_message = close_next_tabs_message.getAttribute('label');
     close_next_tabs_message.setAttribute('label', 'Close Tabs Below');
 
-    //remove option to hide new-tab-button
-    let parentMenu = document.getElementById('toolbar-context-menu');
-    let moveToPanelMenuItem = parentMenu.removeChild(document.querySelector('.customize-context-moveToPanel'));
-    let removeFromToolbarMenuItem = parentMenu.removeChild(document.querySelector('.customize-context-removeFromToolbar'));
+    //remove option to movetopanel or removefromtoolbar from the new-tab-button
+    let oldOnViewToolbarsPopupShowing = window.onViewToolbarsPopupShowing;
+    window.onViewToolbarsPopupShowing = function (aEvent, aInsertPoint) {
+      oldOnViewToolbarsPopupShowing(aEvent, aInsertPoint);
+      if (aEvent.explicitOriginalTarget.id === 'new-tab-button') {
+        aEvent.target.querySelector('.customize-context-moveToPanel').setAttribute('disabled', true);
+        aEvent.target.querySelector('.customize-context-removeFromToolbar').setAttribute('disabled', true);
+      }
+    };
 
     let enter = (event) => {
       this.mouseEntered();
@@ -548,8 +552,7 @@ VerticalTabs.prototype = {
       window.removeEventListener('aftercustomization', afterListener);
 
       //restore the changed menu items
-      parentMenu.insertBefore(removeFromToolbarMenuItem, parentMenu.firstChild);
-      parentMenu.insertBefore(moveToPanelMenuItem, removeFromToolbarMenuItem);
+      window.onViewToolbarsPopupShowing = oldOnViewToolbarsPopupShowing;
       close_next_tabs_message.setAttribute('label', previous_close_message);
 
       // Put the tabs back up top

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -315,6 +315,12 @@ VerticalTabs.prototype = {
       }
     }
 
+    //if new tab button is not in toolbar, find it and insert it.
+    if (!toolbar.querySelector('#new-tab-button')) {
+      let NewTabButton = document.getElementById('new-tab-button');
+      toolbar.insertBefore(NewTabButton, toolbar.firstChild);
+    }
+
     contentbox.insertBefore(top, contentbox.firstChild);
 
     // Create a box next to the app content. It will hold the tab

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -317,6 +317,7 @@ VerticalTabs.prototype = {
 
     //if new tab button is not in toolbar, find it and insert it.
     if (!toolbar.querySelector('#new-tab-button')) {
+      //TODO save position of button for restoring later
       let NewTabButton = document.getElementById('new-tab-button');
       toolbar.insertBefore(NewTabButton, toolbar.firstChild);
     }
@@ -436,6 +437,11 @@ VerticalTabs.prototype = {
     let previous_close_message = close_next_tabs_message.getAttribute('label');
     close_next_tabs_message.setAttribute('label', 'Close Tabs Below');
 
+    //remove option to hide new-tab-button
+    let parentMenu = document.getElementById('toolbar-context-menu');
+    let moveToPanelMenuItem = parentMenu.removeChild(document.querySelector('.customize-context-moveToPanel'));
+    let removeFromToolbarMenuItem = parentMenu.removeChild(document.querySelector('.customize-context-removeFromToolbar'));
+
     let enter = (event) => {
       this.mouseEntered();
       if (event.type === 'mouseenter' && leftbox.getAttribute('expanded') !== 'true') {
@@ -532,6 +538,9 @@ VerticalTabs.prototype = {
       window.removeEventListener('customizationchange', changeListener);
       window.removeEventListener('aftercustomization', afterListener);
 
+      //restore the changed menu items
+      parentMenu.insertBefore(removeFromToolbarMenuItem, parentMenu.firstChild);
+      parentMenu.insertBefore(moveToPanelMenuItem, removeFromToolbarMenuItem);
       close_next_tabs_message.setAttribute('label', previous_close_message);
 
       // Put the tabs back up top

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -317,9 +317,16 @@ VerticalTabs.prototype = {
 
     //if new tab button is not in toolbar, find it and insert it.
     if (!toolbar.querySelector('#new-tab-button')) {
-      //TODO save position of button for restoring later
+      //save position of button for restoring later
       let NewTabButton = document.getElementById('new-tab-button');
+      let NewTabButtonParent = NewTabButton.parentNode;
+      let NewTabButtonSibling = NewTabButton.nextSibling;
       toolbar.insertBefore(NewTabButton, toolbar.firstChild);
+
+      this.unloaders.push(function () {
+        // put the newTab button back where it belongs
+        NewTabButtonParent.insertBefore(NewTabButton, NewTabButtonSibling);
+      });
     }
 
     contentbox.insertBefore(top, contentbox.firstChild);

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -35,7 +35,7 @@
  *
  * ***** END LICENSE BLOCK ***** */
 
-/* global require, exports:false, PageThumbs:false */
+/* global require, exports:false, PageThumbs:false, CustomizableUI:false */
 'use strict';
 
 const {Cc, Ci, Cu} = require('chrome');
@@ -47,6 +47,7 @@ const {createExposableURI} = Cc['@mozilla.org/docshell/urifixup;1'].
                                createInstance(Ci.nsIURIFixup);
 
 Cu.import('resource://gre/modules/PageThumbs.jsm');
+Cu.import('resource:///modules/CustomizableUI.jsm');
 
 //use to set preview image as metadata image 1/4
 // Components.utils.import('resource://gre/modules/XPCOMUtils.jsm');
@@ -318,7 +319,8 @@ VerticalTabs.prototype = {
     //if new tab button is not in toolbar, find it and insert it.
     if (!toolbar.querySelector('#new-tab-button')) {
       //save position of button for restoring later
-      let NewTabButton = document.getElementById('new-tab-button');
+      let NewTabButton = document.getElementById('new-tab-button') || CustomizableUI.getWidget('new-tab-button').forWindow(this.window).node;
+
       let NewTabButtonParent = NewTabButton.parentNode;
       let NewTabButtonSibling = NewTabButton.nextSibling;
       toolbar.insertBefore(NewTabButton, toolbar.firstChild);


### PR DESCRIPTION
reviewer: @bwinton 

- disable options to "Move to Menu" and "Remove from Toolbar" from the new tab button
- find the new-tab-button if located inside customization-container or panel, and rebuild it in toolbar.
- put button back after

Fixes: #471.
Fixes: #554. (hopefully)