### PR TITLE
fix: Snap open the sidebar when the cursor is slammed all the way left.

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -190,7 +190,7 @@
   background-color: hsl(0, 0%, 99%) !important;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0), inset 0 0 10px hsla(0, 0%, 0%, 0.2);
   flex-direction: column;
-  transition: box-shadow 150ms ease-out 300ms, width 150ms ease-out 300ms;
+  transition: box-shadow 150ms ease-out, width 150ms ease-out;
 }
 
 #verticaltabs-box[brighttext] {
@@ -232,7 +232,7 @@
 #main-window[tabspinned="true"] #verticaltabs-box {
   width: var(--pinned-width);
   box-shadow: none;
-  transition: box-shadow 0ms ease-in-out 0ms;
+  transition: box-shadow 0ms ease-in-out;
 }
 
 #alltabs-button {

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -455,17 +455,22 @@ VerticalTabs.prototype = {
       }
     };
 
+    let enterTimeout = -1;
+
     let enter = (event) => {
       this.mouseEntered();
       if (event.type === 'mouseenter' && leftbox.getAttribute('expanded') !== 'true') {
         this.stats.tab_center_expanded++;
-        leftbox.setAttribute('expanded', 'true');
+        enterTimeout = window.setTimeout(() => {
+          leftbox.setAttribute('expanded', 'true');
+        }, 300);
       }
       if (event.pageX <= 4) {
-        leftbox.style.transition = 'box-shadow 150ms ease-out, width 150ms ease-out';
-        window.setTimeout(() => {
-          leftbox.style.transition = '';
-        }, 300);
+        if (enterTimeout > 0) {
+          window.clearTimeout(enterTimeout);
+          enterTimeout = -1;
+        }
+        leftbox.setAttribute('expanded', 'true');
       }
       window.setTimeout(() => {
         for (let i = 0; i < tabs.childNodes.length; i++) {
@@ -478,6 +483,10 @@ VerticalTabs.prototype = {
     leftbox.addEventListener('mousemove', enter);
     leftbox.addEventListener('mouseleave', () => {
       this.mouseExited();
+      if (enterTimeout > 0) {
+        window.clearTimeout(enterTimeout);
+        enterTimeout = -1;
+      }
       if (mainWindow.getAttribute('tabspinned') !== 'true') {
         leftbox.removeAttribute('expanded');
         this.clearFind();


### PR DESCRIPTION
Move the delay from CSS to JavaScript, so that we can more easily control it.
Then use a setTimeout to add the delay.  And don't forget to clear it!

Reviewer: @ericawright
Fixes #331.
