### PR TITLE
fix: Stop auto-scrolling forever when dragging over an arrow button…  ⏳

### DIFF
--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -28,7 +28,9 @@
         this._scrollButtonUp.ondragover = function (event) {
           _distanceScroll(event);
         };
-        this._scrollButtonUp.ondragleave = _stopScroll();
+        this._scrollButtonUp.ondragexit = function (event) {
+          _stopScroll();
+        };
 
         this._scrollButtonDown.ondragenter = function (event) {
           if (event.button === 0) {
@@ -38,7 +40,9 @@
         this._scrollButtonDown.ondragover = function (event) {
           _distanceScroll(event);
         };
-        this._scrollButtonDown.ondragleave = _stopScroll();
+        this._scrollButtonDown.ondragexit = function (event) {
+          _stopScroll();
+        };
 
         this.setAttribute('notoverflowing', 'true');
         this._updateScrollButtonsDisabledState();

--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -66,8 +66,6 @@
 
         if (tabs.tabbrowser.clientHeight >= this.clientHeight) {
           this.removeAttribute('notoverflowing');
-        } else {
-          this.addAttribute('notoverflowing', true);
         }
 
         if (tabs._lastTabClosedByMouse) {
@@ -85,8 +83,6 @@
 
         if (tabs.tabbrowser.clientHeight >= this.clientHeight) {
           this.removeAttribute('notoverflowing');
-        } else {
-          this.addAttribute('notoverflowing', true);
         }
 
         let numberOfTabs = tabs.tabbrowser.visibleTabs.length;


### PR DESCRIPTION
Look for `ondragexit` instead of `ondragleave`, since apparently `ondragleave` doesn't get called.  ¯\_(ツ)_/¯

Reviewer: @ericawright
Fixes #548.