### PR TITLE
Fix: window controls in fullscreen

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -568,6 +568,8 @@ VerticalTabs.prototype = {
 
     this.unloaders.push(function () {
       autocomplete._openAutocompletePopup = autocompleteOpen;
+      window.FullScreen._updateToolbars = oldUpdateToolbars;
+      window.FullScreen.hideNavToolbox = oldHideNavToolbox;
 
       // Move the tabs toolbar back to where it was
       toolbar._toolbox = null; // reset value set by constructor

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -497,6 +497,31 @@ VerticalTabs.prototype = {
       }
     });
 
+    let oldUpdateToolbars = window.FullScreen._updateToolbars;
+    window.FullScreen._updateToolbars = (aEnterFS) => {
+      oldUpdateToolbars.bind(window.FullScreen)(aEnterFS);
+      let fullscreenctls = document.getElementById('window-controls');
+      let navbar = document.getElementById('nav-bar');
+      let toggler = document.getElementById('fullscr-toggler');
+      let sibling = document.getElementById('navigator-toolbox').nextSibling;
+
+      if (aEnterFS && fullscreenctls.parentNode.id === 'TabsToolbar') {
+        navbar.appendChild(fullscreenctls);
+        toggler.removeAttribute('hidden');
+        window.gNavToolbox.style.marginTop = (-window.gNavToolbox.getBoundingClientRect().height - 1) + 'px';
+        document.getElementById('appcontent').insertBefore(toggler, sibling);
+      }
+    };
+
+    //hidden nav toolbox needs to be moved 1 pix higher to account for the toggler every time it hides
+    let oldHideNavToolbox = window.FullScreen.hideNavToolbox;
+    window.FullScreen.hideNavToolbox = (aAnimate = false) => {
+      oldHideNavToolbox.bind(window.FullScreen)(aAnimate);
+      let toggler = document.getElementById('fullscr-toggler');
+      toggler.removeAttribute('hidden');
+      window.gNavToolbox.style.marginTop = (-window.gNavToolbox.getBoundingClientRect().height - 1) + 'px';
+    };
+
     tabs.addEventListener('TabOpen', this, false);
     tabs.addEventListener('TabClose', this, false);
     tabs.addEventListener('TabPinned', this, false);


### PR DESCRIPTION
@bwinton 

Hide the window controls if they were moved to the TabsToolbar. 
Move the fullscr-toggler to be above the main window, instead of above tab center

notes: currently adding window controls to the #nav-bar. would like to add to the #titlebar but it will not work with the slide in out/toggle on mousing up.

Fixes: #509.