### PR TITLE
fix: Only load thumbnails when tabs are large

### DIFF
--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -652,19 +652,20 @@
           }
           let uri = VerticalTabs.getUri(this);
           let url = uri.spec;
-          const canvas = document.getAnonymousElementByAttribute(this, 'anonid', 'tab-meta-image');
-
-          if (VerticalTabs.newTabImage && (url === 'about:newtab' || url === 'about:blank')) {
-            const ctx = canvas.getContext('2d');
-            ctx.save();
-            ctx.scale(
-              canvas.width / VerticalTabs.newTabImage.width,
-              canvas.height / VerticalTabs.newTabImage.height
-              );
-            ctx.drawImage(VerticalTabs.newTabImage, 0, 0);
-            ctx.restore();
-          } else {
-            PageThumbs.captureToCanvas(this.linkedBrowser, canvas);
+          if (this.parentNode.classList.contains('large-tabs')) {
+            const canvas = document.getAnonymousElementByAttribute(this, 'anonid', 'tab-meta-image');
+            if (VerticalTabs.newTabImage && (url === 'about:newtab' || url === 'about:blank')) {
+              const ctx = canvas.getContext('2d');
+              ctx.save();
+              ctx.scale(
+                canvas.width / VerticalTabs.newTabImage.width,
+                canvas.height / VerticalTabs.newTabImage.height
+                );
+              ctx.drawImage(VerticalTabs.newTabImage, 0, 0);
+              ctx.restore();
+            } else {
+              PageThumbs.captureToCanvas(this.linkedBrowser, canvas);
+            }
           }
           this.updateUriLabel(uri);
         ]]></body>

--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -652,25 +652,27 @@
           }
           let uri = VerticalTabs.getUri(this);
           let url = uri.spec;
-          if (this.parentNode.classList.contains('large-tabs')) {
-            const canvas = document.getAnonymousElementByAttribute(this, 'anonid', 'tab-meta-image');
-            if (VerticalTabs.newTabImage && (url === 'about:newtab' || url === 'about:blank')) {
-              const ctx = canvas.getContext('2d');
-              ctx.save();
-              ctx.scale(
-                canvas.width / VerticalTabs.newTabImage.width,
-                canvas.height / VerticalTabs.newTabImage.height
-                );
-              ctx.drawImage(VerticalTabs.newTabImage, 0, 0);
-              ctx.restore();
-            } else {
-              PageThumbs.captureToCanvas(this.linkedBrowser, canvas);
-            }
-          }
           this.updateUriLabel(uri);
+
+          if (!this.parentNode.classList.contains('large-tabs')) {
+            // no need for images.  Bail.
+            return;
+          }
+          const canvas = document.getAnonymousElementByAttribute(this, 'anonid', 'tab-meta-image');
+          if (VerticalTabs.newTabImage && (url === 'about:newtab' || url === 'about:blank')) {
+            const ctx = canvas.getContext('2d');
+            ctx.save();
+            ctx.scale(
+              canvas.width / VerticalTabs.newTabImage.width,
+              canvas.height / VerticalTabs.newTabImage.height
+              );
+            ctx.drawImage(VerticalTabs.newTabImage, 0, 0);
+            ctx.restore();
+          } else {
+            PageThumbs.captureToCanvas(this.linkedBrowser, canvas);
+          }
         ]]></body>
       </method>
-
 
       <method name="updateUriLabel">
         <parameter name="uri"/>

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -763,6 +763,7 @@ VerticalTabs.prototype = {
       let number_of_tabs = this.document.querySelectorAll('.tabbrowser-tab:not([hidden=true])').length;
       if (tabbrowser_height / number_of_tabs >= 58 && this.pinnedWidth > 60) {
         tabs.classList.add('large-tabs');
+        this.refreshAllTabs();
       } else {
         tabs.classList.remove('large-tabs');
       }
@@ -771,6 +772,13 @@ VerticalTabs.prototype = {
     case 2:
       tabs.classList.add('large-tabs');
       return;
+    }
+  },
+
+  refreshAllTabs: function () {
+    let tabs = this.document.getElementById('tabbrowser-tabs');
+    for (let tab of tabs.childNodes) {
+      tab.refreshThumbAndLabel();
     }
   },
 


### PR DESCRIPTION
r: @bwinton 

When tab count gets reduced to amount where large tabs show, load all thumbs one time.
Only load thumbs on new tabs if parent has class 'large-tabs'.

fixes: #607. (at least partially)