### PR TITLE
fix: Delete tabs without waiting for animation to finish 🐎 🏁

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -151,6 +151,7 @@ VerticalTabs.prototype = {
     });
 
     window.gBrowser._endRemoveTab = (aTab) => {
+      window.gBrowser._blurTab(aTab);
       aTab.classList.add('tab-hidden');
     };
 


### PR DESCRIPTION
r: @bwinton 

when removing a tab change focus before animating out :D

fixes: #306.