### PR TITLE
style: remove gradient from dark dev edition theme

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -812,3 +812,8 @@
   background-repeat: no-repeat !important;
   background-size: 16px !important;
 }
+
+/*stop the gradient from dev edition theme*/
+#navigator-toolbox > toolbar:not(#TabsToolbar):not(#toolbar-menubar) {
+  background: transparent none repeat scroll 0% 0% !important;
+}


### PR DESCRIPTION
r: @bwinton 

fixes: https://github.com/bwinton/TabCenter/issues/566

was happening due to this `background-image`:
<img width="451" alt="screen shot 2016-09-23 at 3 03 32 pm" src="https://cloud.githubusercontent.com/assets/10803178/18802630/d2ffa912-819e-11e6-98e1-33f600107dab.png">
