### PR TITLE
fix: hide in fullscreen

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -171,6 +171,27 @@
   transition: box-shadow 150ms ease-out, width 150ms ease-out;
 }
 
+#main-window[F11-fullscreen] #verticaltabs-box {
+  width: 0 !important;
+  transition: width 1s linear;
+}
+
+#main-window[F11-fullscreen] #appcontent
+#main-window[tabspinned="true"][F11-fullscreen] #appcontent,
+#main-window[F11-fullscreen] #sidebar-box[hidden="true"] ~ #appcontent {
+  width: 100vw !important;
+  margin-left: 0 !important;
+  transition: margin-left 1s linear, width 1s linear;
+}
+
+#main-window[tabspinned="true"][F11-fullscreen] #verticaltabs-splitter {
+  width: 0 !important;
+  margin-left: 0 !important;
+  min-width: 0 !important;
+  max-width: 0 !important;
+  transition: margin-left 1s linear;
+}
+
 #verticaltabs-box[brighttext] {
   background-color: hsla(0, 0%, 20%, 0.98) !important;
 }

--- a/skin/base.css
+++ b/skin/base.css
@@ -172,16 +172,20 @@
 }
 
 #main-window[F11-fullscreen] #verticaltabs-box {
-  width: 0 !important;
-  transition: width 1s linear;
+  width: 1px !important;
+  transition: none;
+}
+
+#main-window[F11-fullscreen] #verticaltabs-box:hover {
+  width: var(--pinned-width) !important;
 }
 
 #main-window[F11-fullscreen] #appcontent
 #main-window[tabspinned="true"][F11-fullscreen] #appcontent,
 #main-window[F11-fullscreen] #sidebar-box[hidden="true"] ~ #appcontent {
-  width: 100vw !important;
-  margin-left: 0 !important;
-  transition: margin-left 1s linear, width 1s linear;
+  width: (100vw - 1px) !important;
+  margin-left: 1px !important;
+  transition: margin-left 500ms linear;
 }
 
 #main-window[tabspinned="true"][F11-fullscreen] #verticaltabs-splitter {
@@ -189,7 +193,7 @@
   margin-left: 0 !important;
   min-width: 0 !important;
   max-width: 0 !important;
-  transition: margin-left 1s linear;
+  transition: margin-left 500ms linear;
 }
 
 #verticaltabs-box[brighttext] {

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -598,6 +598,11 @@ VerticalTabs.prototype = {
         window.gNavToolbox.style.marginTop = (-window.gNavToolbox.getBoundingClientRect().height - 1) + 'px';
         document.getElementById('appcontent').insertBefore(toggler, sibling);
       }
+      if (aEnterFS) {
+        mainWindow.setAttribute('F11-fullscreen', 'true');
+      } else {
+        mainWindow.removeAttribute('F11-fullscreen');
+      }
     };
 
     //hidden nav toolbox needs to be moved 1 pix higher to account for the toggler every time it hides

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -595,21 +595,13 @@ VerticalTabs.prototype = {
       if (aEnterFS && fullscreenctls.parentNode.id === 'TabsToolbar') {
         navbar.appendChild(fullscreenctls);
         toggler.removeAttribute('hidden');
+        //hidden nav toolbox needs to be moved 1 pix higher to account for the toggler every time it hides
         window.gNavToolbox.style.marginTop = (-window.gNavToolbox.getBoundingClientRect().height - 1) + 'px';
         document.getElementById('appcontent').insertBefore(toggler, sibling);
         mainWindow.setAttribute('F11-fullscreen', 'true');
       } else {
         mainWindow.removeAttribute('F11-fullscreen');
       }
-    };
-
-    //hidden nav toolbox needs to be moved 1 pix higher to account for the toggler every time it hides
-    let oldHideNavToolbox = window.FullScreen.hideNavToolbox;
-    window.FullScreen.hideNavToolbox = (aAnimate = false) => {
-      oldHideNavToolbox.bind(window.FullScreen)(aAnimate);
-      let toggler = document.getElementById('fullscr-toggler');
-      toggler.removeAttribute('hidden');
-      window.gNavToolbox.style.marginTop = (-window.gNavToolbox.getBoundingClientRect().height - 1) + 'px';
     };
 
     tabs.addEventListener('TabOpen', this, false);
@@ -647,7 +639,6 @@ VerticalTabs.prototype = {
     this.unloaders.push(function () {
       autocomplete._openAutocompletePopup = autocompleteOpen;
       window.FullScreen._updateToolbars = oldUpdateToolbars;
-      window.FullScreen.hideNavToolbox = oldHideNavToolbox;
 
       // Move the tabs toolbar back to where it was
       toolbar._toolbox = null; // reset value set by constructor

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -597,8 +597,6 @@ VerticalTabs.prototype = {
         toggler.removeAttribute('hidden');
         window.gNavToolbox.style.marginTop = (-window.gNavToolbox.getBoundingClientRect().height - 1) + 'px';
         document.getElementById('appcontent').insertBefore(toggler, sibling);
-      }
-      if (aEnterFS) {
         mainWindow.setAttribute('F11-fullscreen', 'true');
       } else {
         mainWindow.removeAttribute('F11-fullscreen');


### PR DESCRIPTION
r: @bwinton
- for Windows and Linux tabs will now tuck out of the way for F11 fullscreen
- for Mac, awesome bar will not hide in fullscreen

fixes: #660
fixes: #307 
fixes: #642