### PR TITLE
fix: don't clear search on mouse out when open

### DIFF
--- a/main.js
+++ b/main.js
@@ -176,6 +176,7 @@ exports.main = function (options, callbacks) {
           input.blur();
           if (mainWindow.getAttribute('tabspinned') !== 'true') {
             sidebar.removeAttribute('expanded');
+            window.VerticalTabs.clearFind();
           }
         } else {
           sidebar.setAttribute('search_expanded', 'true');

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -522,11 +522,9 @@ VerticalTabs.prototype = {
           window.clearTimeout(enterTimeout);
           enterTimeout = -1;
         }
-        if (mainWindow.getAttribute('tabspinned') !== 'true') {
-          if (!leftbox.contextMenuOpen){
-            leftbox.removeAttribute('expanded');
-            this.clearFind();
-          }
+        if (mainWindow.getAttribute('tabspinned') !== 'true' && leftbox.getAttribute('search_expanded') !== 'true' && !leftbox.contextMenuOpen) {
+          leftbox.removeAttribute('expanded');
+          this.clearFind();
           let tabsPopup = document.getElementById('alltabs-popup');
           if (tabsPopup.state === 'open') {
             tabsPopup.hidePopup();


### PR DESCRIPTION
r: @bwinton 

- search is no longer cleared on mouse out when drawer remains open from hotkey toggle
- search is cleared when hotkey toggle closes drawer

fixes: #663