### PR TITLE
Change how TabCenter CSS is loaded & Clean up TabCenter CSS

### DIFF
--- a/main.js
+++ b/main.js
@@ -88,6 +88,9 @@ function initWindow(window) {
 
   let data = b64toBlob(win, self.data.load('newtab.b64'), 'image/png');
 
+  // Add the stylesheets
+  utils.installStylesheets(win);
+
   // check for browser windows with visible toolbars
   if (!win.toolbar.visible || !isBrowser(win)) {
     return;
@@ -133,9 +136,6 @@ exports.main = function (options, callbacks) {
 
   // Override default preferences
   utils.setDefaultPrefs();
-
-  // Install the stylesheets
-  utils.installStylesheets();
 
   // Startup VerticalTabs object for each window.
   browserWindows.on('open', initWindow);
@@ -221,10 +221,9 @@ exports.onUnload = function (reason) {
       tabs.removeAttribute('overflow');
       tabs._positionPinnedTabs();
     }
+    // Remove the stylesheets
+    utils.removeStylesheets(win);
   }
-
-  // Remove the stylesheets
-  utils.removeStylesheets();
 
   // Restore default preferences
   utils.removeDefaultPrefs();

--- a/skin/base.css
+++ b/skin/base.css
@@ -720,20 +720,20 @@
   display: none;
 }
 
-#TabsToolbar > toolbarbutton {
+#verticaltabs-box #TabsToolbar > toolbarbutton {
   border: 1px solid transparent !important;
-  box-sizing: border-box !important;
+  box-sizing: border-box;
   height: 26px !important;
   min-height: 26px !important;
   background-image: none !important;
 }
 
-#TabsToolbar > toolbarbutton:hover {
+#verticaltabs-box #TabsToolbar > toolbarbutton:hover {
   border: 1px solid hsla(0, 0%, 0%, 0.16) !important;
   background-color: hsla(0, 0%, 0%, 0.1) !important;
 }
 
-#TabsToolbar > toolbarbutton:hover:active {
+#verticaltabs-box #TabsToolbar > toolbarbutton:hover:active {
   border: 1px solid hsla(0, 0%, 0%, 0.16) !important;
   background-color: hsla(0, 0%, 0%, 0.16) !important;
   box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.1) inset !important;
@@ -836,9 +836,4 @@
   background-position: -8px center !important;
   background-repeat: no-repeat !important;
   background-size: 16px !important;
-}
-
-/*stop the gradient from dev edition theme*/
-#navigator-toolbox > toolbar:not(#TabsToolbar):not(#toolbar-menubar) {
-  background: transparent none repeat scroll 0% 0% !important;
 }

--- a/skin/base.css
+++ b/skin/base.css
@@ -269,6 +269,7 @@
 }
 
 #TabsToolbar #find-input {
+  display: flex;
   margin: 0 4px !important;
   padding: 0 !important;
   height: 26px;
@@ -291,7 +292,6 @@
 
 #tabs-search {
   display: block;
-  margin: 2px 0;
   min-width: 20px;
   max-width: 20px;
   -moz-image-region: rect(0, 20px, 20px, 0);
@@ -304,8 +304,6 @@
 
 #find-input .textbox-input-box {
   display: block;
-  margin-left: 20px;
-  max-width: calc(100% - 20px) !important;
 }
 
 /* [inDOMFullscreen] for video */
@@ -715,11 +713,11 @@
 }
 
 #verticaltabs-box #TabsToolbar > toolbarbutton {
-  -moz-appearance: none;
   border: 1px solid transparent !important;
   box-sizing: border-box;
   height: 26px !important;
   min-height: 26px !important;
+  -moz-appearance: none;
   background-image: none !important;
 }
 

--- a/skin/base.css
+++ b/skin/base.css
@@ -24,8 +24,8 @@
   overflow-y: auto !important;
 }
 
-.tabbrowser-arrowscrollbox  .scrollbutton-up,
-.tabbrowser-arrowscrollbox  .scrollbutton-down {
+.tabbrowser-arrowscrollbox .scrollbutton-up,
+.tabbrowser-arrowscrollbox .scrollbutton-down {
   visibility: collapse !important;
 }
 
@@ -180,8 +180,6 @@
   width: var(--pinned-width) !important;
 }
 
-#main-window[F11-fullscreen] #appcontent
-#main-window[tabspinned="true"][F11-fullscreen] #appcontent,
 #main-window[F11-fullscreen] #sidebar-box[hidden="true"] ~ #appcontent {
   width: (100vw - 1px) !important;
   margin-left: 1px !important;
@@ -242,19 +240,16 @@
   visibility: hidden;
 }
 
-#TabsToolbar > #pin-button {
+#verticaltabs-box #TabsToolbar > #pin-button {
   z-index: 1;
   width: 32px;
   min-width: 32px;
   margin: 0 8px 0 4px !important;
-  display: -moz-box;
-  -moz-appearance: none !important;
   background-image: url("resource://tabcenter/skin/glyph-sidebar-expand-16.svg") !important;
   background-position: center;
   background-repeat: no-repeat;
   background-size: 16px;
   -moz-box-flex: 0;
-  opacity: 0;
   transition: opacity 125ms ease-in-out 300ms;
 }
 
@@ -338,10 +333,9 @@
   background-image: url("resource://tabcenter/skin/glyph-sidebar-collapse-inverted-16.svg") !important;
 }
 
-#verticaltabs-box[expanded="true"] #pin-button,
-#verticaltabs-box[search_expanded="true"] #pin-button,
-#main-window[tabspinned="true"] #pin-button {
-  opacity: 1;
+#main-window:not([tabspinned="true"])
+#verticaltabs-box:not([expanded="true"]):not([search_expanded="true"]) #pin-button {
+  opacity: 0;
 }
 
 #appcontent {
@@ -715,12 +709,13 @@
   border-bottom: 1px solid hsla(0, 0%, 0%, 0.5) !important;
 }
 
-#TabsToolbar > toolbarbutton,
+#TabsToolbar > toolbarbutton:not(#pin-button):not(#new-tab-button),
 #TabsToolbar > toolbaritem {
   display: none;
 }
 
 #verticaltabs-box #TabsToolbar > toolbarbutton {
+  -moz-appearance: none;
   border: 1px solid transparent !important;
   box-sizing: border-box;
   height: 26px !important;
@@ -740,7 +735,6 @@
 }
 
 #TabsToolbar > #new-tab-button {
-  display: -moz-box !important;
   margin: 0 4px !important;
   padding: 0 6px !important;
   min-width: 40px !important;

--- a/skin/linux.css
+++ b/skin/linux.css
@@ -62,7 +62,3 @@
 #main-window[devedition-theme] .tabbrowser-arrowscrollbox {
   height: calc(100vh - 41px);
 }
-
-#find-input .textbox-input-box {
-  margin-top: -25px;
-}

--- a/skin/osx.css
+++ b/skin/osx.css
@@ -80,6 +80,15 @@
   margin-top: -19px;
 }
 
+#main-window:not([devedition-theme]) #navigator-toolbox > toolbar:not(#TabsToolbar):-moz-lwtheme {
+  background-color: transparent !important;
+  background-image: linear-gradient(hsla(0, 0%, 100%, 0), hsla(0, 0%, 100%, 0.65)) !important;
+}
+
+#navigator-toolbox > toolbar:not(#TabsToolbar):-moz-lwtheme {
+  box-shadow: none !important;
+}
+
 .tabbrowser-arrowscrollbox {
   height: calc(100vh - 61px);
 }

--- a/skin/osx.css
+++ b/skin/osx.css
@@ -76,10 +76,6 @@
   transition-duration: 150ms !important;
 }
 
-#find-input .textbox-input-box {
-  margin-top: -19px;
-}
-
 #main-window:not([devedition-theme]) #navigator-toolbox > toolbar:not(#TabsToolbar):-moz-lwtheme {
   background-color: transparent !important;
   background-image: linear-gradient(hsla(0, 0%, 100%, 0), hsla(0, 0%, 100%, 0.65)) !important;

--- a/skin/osx.css
+++ b/skin/osx.css
@@ -12,17 +12,17 @@
   border-top: 0 !important;
 }
 
-#TabsToolbar > toolbarbutton {
+#verticaltabs-box #TabsToolbar > toolbarbutton {
   padding: 0 5px !important;
   border-radius: 2.5px !important;
 }
 
-#TabsToolbar > toolbarbutton:hover {
+#verticaltabs-box #TabsToolbar > toolbarbutton:hover {
   border: 1px solid hsla(0, 0%, 0%, 0.16) !important;
   background-color: hsla(0, 0%, 0%, 0.1) !important;
 }
 
-#TabsToolbar > toolbarbutton:hover:active {
+#verticaltabs-box #TabsToolbar > toolbarbutton:hover:active {
   border: 1px solid hsla(0, 0%, 0%, 0.16) !important;
   background-color: hsla(0, 0%, 0%, 0.16) !important;
   box-shadow: none !important;
@@ -78,12 +78,6 @@
 
 #find-input .textbox-input-box {
   margin-top: -19px;
-}
-
-#navigator-toolbox > toolbar:not(#TabsToolbar):-moz-lwtheme {
-  background-color: transparent !important;
-  background-image: linear-gradient(hsla(0, 0%, 100%, 0), hsla(0, 0%, 100%, 0.65)) !important;
-  box-shadow: none !important;
 }
 
 .tabbrowser-arrowscrollbox {

--- a/skin/win.css
+++ b/skin/win.css
@@ -8,10 +8,6 @@
   width:auto !important;
 }
 
-#find-input .textbox-input-box {
-  margin-top: -25px;
-}
-
 .tabbrowser-arrowscrollbox,
 .tabbrowser-arrowscrollbox:not(:-moz-lwtheme),
 #main-window[devedition-theme] .tabbrowser-arrowscrollbox {

--- a/utils.js
+++ b/utils.js
@@ -127,8 +127,7 @@ exports.removeDefaultPrefs = removeDefaultPrefs;
 /* Stylesheets */
 
 const {newURI} = require('sdk/url/utils');
-const {loadAndRegisterSheet, unregisterSheet, USER_SHEET} = Cc['@mozilla.org/content/style-sheet-service;1'].
-                                                              getService(Ci.nsIStyleSheetService);
+const {loadSheet, removeSheet} = require('sdk/stylesheet/utils');
 
 const STYLESHEETS = [
   'resource://tabcenter/override-bindings.css',
@@ -136,16 +135,16 @@ const STYLESHEETS = [
   'chrome://tabcenter/skin/platform.css'
 ];
 
-function installStylesheets() {
+function installStylesheets(win) {
   for (let uri of STYLESHEETS) {
-    loadAndRegisterSheet(newURI(uri), USER_SHEET);
+    loadSheet(win, uri, 'author');
   }
 }
 exports.installStylesheets = installStylesheets;
 
-function removeStylesheets() {
+function removeStylesheets(win) {
   for (let uri of STYLESHEETS) {
-    unregisterSheet(newURI(uri), USER_SHEET);
+    removeSheet(win, uri, 'author');
   }
 }
 exports.removeStylesheets = removeStylesheets;


### PR DESCRIPTION
Summary of changes:
- Change how TabCenter CSS is loaded
Before this PR, everything TabCenter sets with CSS is more important than everything else (on top of the chain). Now, TabCenter just follows the normal rules of CSS priority. This simple change allows customization-savy users to override everything else, while still giving importance to TabCenter's CSS.

- Clean up TabCenter CSS
Removed redundant rules, invalid selectors (that were previously simply ignored).
The gradient that TabCenter removes in https://github.com/bwinton/TabCenter/commit/446c3fd1fefbb7a4f97ae6a8e2360520efe887b7 is actually from https://github.com/bwinton/TabCenter/blob/master/skin/osx.css#L85
I've fixed that redundancy as well.
