### PR TITLE
fix: default tabs to open at the bottom

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
   "preferences": [
     {
       "name": "opentabstop",
-      "title": "Tabs on Top",
-      "description": "New tabs are opened at the top",
+      "title": "Open Tabs Above",
+      "description": "Newer tabs are opened above older tabs",
       "type": "bool",
-      "value": true
+      "value": false
     },
     {
       "name": "largetabs",


### PR DESCRIPTION
r: @bwinton 

this was changed previously due to misunderstanding
*sorry to those who will be surprised... again*
