### PR TITLE
style: remove bottom margin from toolbar

### DIFF
--- a/skin/osx.css
+++ b/skin/osx.css
@@ -5,6 +5,7 @@
 }
 
 #verticaltabs-box #TabsToolbar {
+  margin-bottom: 0 !important;
   flex: 0 0 40px !important;
 }
 


### PR DESCRIPTION
r:@bwinton

remove bottom margin from toolbar on mac (you could see it at the top of the scrollbar)