### PR TITLE
fix: on change of overflow, keep scroll position the same

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -19,8 +19,7 @@
   overflow-y: hidden !important;
 }
 
-#main-window[tabspinned="true"] #tabbrowser-tabs[mouseInside] .tabbrowser-arrowscrollbox > scrollbox,
-#main-window:not([tabspinned="true"]) #verticaltabs-box[expanded="true"] .tabbrowser-arrowscrollbox > scrollbox {
+#tabbrowser-tabs[mouseInside] .tabbrowser-arrowscrollbox > scrollbox {
   overflow-y: auto !important;
 }
 

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -831,13 +831,23 @@ VerticalTabs.prototype = {
       this.resizeTimeout = -1;
     }
     this.mouseInside = true;
+    let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
+    let scrollbox = this.document.getAnonymousElementByAttribute(arrowscrollbox, 'anonid', 'scrollbox');
+    let scrolltop = scrollbox.scrollTop;
+
     tabs.setAttribute('mouseInside', 'true');
+    scrollbox.scrollTop = scrolltop;
   },
 
   mouseExited: function () {
     let tabs = this.document.getElementById('tabbrowser-tabs');
+    let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
+    let scrollbox = this.document.getAnonymousElementByAttribute(arrowscrollbox, 'anonid', 'scrollbox');
+    let scrolltop = scrollbox.scrollTop;
     this.mouseInside = false;
     tabs.removeAttribute('mouseInside');
+    scrollbox.scrollTop = scrolltop;
+
     if (this.resizeTimeout < 0) {
       // Once the mouse exits the tab area, wait
       // a bit before resizing


### PR DESCRIPTION
r: @bwinton

- on mouse out and mouse in, scroll will stay in the same position.

fixes: #669