### PR TITLE
fix: filter only through visible tabs

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -900,6 +900,7 @@ VerticalTabs.prototype = {
   },
 
   onTabClose: function (aEvent) {
+    this.clearFind();
     this.stats.tabs_destroyed++;
   },
 

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -727,13 +727,21 @@ VerticalTabs.prototype = {
 
   clearFind: function () {
     this.document.getElementById('find-input').value = '';
+    if (this.visibleTabs) {
+      for (let i = 0; i < this.visibleTabs.length; i++) {
+        let tab = this.visibleTabs[i];
+        if (tab.getAttribute('pinned') === 'true') {
+          tab.setAttribute('hidden', false);
+        }
+      }
+    }
     this.visibleTabs = null;
     this.filtertabs();
   },
 
   filtertabs: function () {
     let document = this.document;
-    this.visibleTabs = this.visibleTabs || this.window.gBrowser.visibleTabs;
+    this.visibleTabs = this.visibleTabs || Array.filter(this.window.gBrowser.tabs, tab => !tab.hidden && !tab.closing);
     let find_input = document.getElementById('find-input');
     let input_value = find_input.value.toLowerCase();
     let hidden_counter = 0;

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -116,7 +116,7 @@ VerticalTabs.prototype = {
     let tabs = document.getElementById('tabbrowser-tabs');
     let tabsProgressListener = {
       onLocationChange: (aBrowser, aWebProgress, aRequest, aLocation, aFlags) => {
-        for (let tab of tabs.childNodes) {
+        for (let tab of this.window.gBrowser.visibleTabs) {
           if (tab.linkedBrowser === aBrowser) {
             tab.refreshThumbAndLabel();
           }
@@ -125,7 +125,7 @@ VerticalTabs.prototype = {
       onStateChange: (aBrowser, aWebProgress, aRequest, aFlags, aStatus) => {
         if ((aFlags & Ci.nsIWebProgressListener.STATE_STOP) === Ci.nsIWebProgressListener.STATE_STOP) { // eslint-disable-line no-bitwise
           this.adjustCrop();
-          for (let tab of tabs.childNodes) {
+          for (let tab of this.window.gBrowser.visibleTabs) {
             if (tab.linkedBrowser === aBrowser && tab.refreshThumbAndLabel) {
               tab.refreshThumbAndLabel();
             }
@@ -794,7 +794,7 @@ VerticalTabs.prototype = {
       return;
     case 1: {
       let tabbrowser_height = tabs.clientHeight;
-      let number_of_tabs = this.document.querySelectorAll('.tabbrowser-tab:not([hidden=true])').length;
+      let number_of_tabs = this.window.gBrowser.visibleTabs.length;
       if (tabbrowser_height / number_of_tabs >= 58 && this.pinnedWidth > 60) {
         tabs.classList.add('large-tabs');
         this.refreshAllTabs();
@@ -810,8 +810,7 @@ VerticalTabs.prototype = {
   },
 
   refreshAllTabs: function () {
-    let tabs = this.document.getElementById('tabbrowser-tabs');
-    for (let tab of tabs.childNodes) {
+    for (let tab of this.window.gBrowser.visibleTabs) {
       tab.refreshThumbAndLabel();
     }
   },

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -727,13 +727,11 @@ VerticalTabs.prototype = {
 
   clearFind: function () {
     this.document.getElementById('find-input').value = '';
+
+    //manually show pinned tabs after changing groups for the tab groups add-on, as it does not re-show them
     if (this.visibleTabs) {
-      for (let i = 0; i < this.visibleTabs.length; i++) {
-        let tab = this.visibleTabs[i];
-        if (tab.getAttribute('pinned') === 'true') {
-          tab.setAttribute('hidden', false);
-        }
-      }
+      this.visibleTabs.filter(tab => tab.getAttribute('pinned') === 'true')
+                      .forEach(tab => {tab.setAttribute('hidden', false);});
     }
     this.visibleTabs = null;
     this.filtertabs();

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -164,6 +164,10 @@ VerticalTabs.prototype = {
       this.receiveMessage.bind(window.gBrowser)(...args);
     };
 
+    window.gBrowser.tabContainer.addEventListener('TabBarUpdated', () => {
+      this.clearFind();
+    });
+
     window.ToolbarIconColor.inferFromText = function () {
       if (!this._initialized){
         return;
@@ -723,20 +727,21 @@ VerticalTabs.prototype = {
 
   clearFind: function () {
     this.document.getElementById('find-input').value = '';
+    this.visibleTabs = null;
     this.filtertabs();
   },
 
   filtertabs: function () {
     let document = this.document;
-    let tabs = this.window.gBrowser.visibleTabs;
+    this.visibleTabs = this.visibleTabs || this.window.gBrowser.visibleTabs;
     let find_input = document.getElementById('find-input');
     let input_value = find_input.value.toLowerCase();
     let hidden_counter = 0;
     let hidden_tab = document.getElementById('filler-tab');
     let hidden_tab_label = hidden_tab.firstChild;
 
-    for (let i = 0; i < tabs.length; i++) {
-      let tab = tabs[i];
+    for (let i = 0; i < this.visibleTabs.length; i++) {
+      let tab = this.visibleTabs[i];
       if (tab.label.toLowerCase().match(input_value) || this.getUri(tab).spec.toLowerCase().match(input_value)) {
         tab.setAttribute('hidden', false);
       } else {

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -728,15 +728,15 @@ VerticalTabs.prototype = {
 
   filtertabs: function () {
     let document = this.document;
-    let tabs = document.getElementById('tabbrowser-tabs');
+    let tabs = this.window.gBrowser.visibleTabs;
     let find_input = document.getElementById('find-input');
     let input_value = find_input.value.toLowerCase();
     let hidden_counter = 0;
     let hidden_tab = document.getElementById('filler-tab');
-    let hidden_tab_label = hidden_tab.children[0];
+    let hidden_tab_label = hidden_tab.firstChild;
 
-    for (let i = 0; i < tabs.children.length; i++) {
-      let tab = tabs.children[i];
+    for (let i = 0; i < tabs.length; i++) {
+      let tab = tabs[i];
       if (tab.label.toLowerCase().match(input_value) || this.getUri(tab).spec.toLowerCase().match(input_value)) {
         tab.setAttribute('hidden', false);
       } else {


### PR DESCRIPTION
r: @bwinton 

- Make `filtertabs` Tab Groups compatible
- Resize tabs according to the visible tabs, not all (only testable in test pilot version)
- `clearFind` or removing a tab
- `clearFind` on changing tab groups

fixes: #692 