### PR TITLE
fix: do not scroll selected tab into view on mouse out/in

### DIFF
--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -363,6 +363,54 @@
           return tabs.length;
         ]]></body>
       </method>
+
+      <method name="_notifyBackgroundTab">
+        <parameter name="aTab"/>
+        <body><![CDATA[
+          if (aTab.pinned || aTab.hidden) {
+            return;
+          }
+
+          let scrollRect = this.mTabstrip.scrollClientRect;
+          let tab = aTab.getBoundingClientRect();
+          this.mTabstrip._calcTabMargins(aTab);
+
+          // DOMRect top/bottom properties are immutable.
+          tab = {top: tab.top, bottom: tab.bottom};
+
+          // Is the new tab already completely visible?
+          if (scrollRect.top <= tab.top && tab.bottom <= scrollRect.bottom){
+            return;
+          }
+
+          if (this.mTabstrip.smoothScroll) {
+            let selected = !this.selectedItem.pinned &&
+                           this.selectedItem.getBoundingClientRect();
+            if (selected) {
+              selected = {top: selected.top, bottom: selected.bottom};
+            }
+
+            // Can we make both the new tab and the selected tab completely visible?
+            if (!selected ||
+                Math.max(tab.bottom - selected.top, selected.bottom - tab.top) <=
+                  scrollRect.height) {
+              this.mTabstrip.ensureElementIsVisible(aTab);
+              return;
+            }
+
+            this.mTabstrip._smoothScrollByPixels(this.mTabstrip._isRTLScrollbox ?
+                                                 selected.bottom - scrollRect.bottom :
+                                                 selected.top - scrollRect.top);
+          }
+
+          if (!this._animateElement.hasAttribute('notifybgtab')) {
+            this._animateElement.setAttribute('notifybgtab', 'true');
+            setTimeout(function (ele) {
+              ele.removeAttribute('notifybgtab');
+            }, 150, this._animateElement);
+          }
+        ]]></body>
+      </method>
     </implementation>
 
     <handlers>

--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -22,7 +22,9 @@
       <method name="_canScrollToElement">
         <parameter name="tab"/>
         <body><![CDATA[
-          return !tab.hidden;
+          let canScroll = !tab.hidden && !this.skipNextScroll;
+          this.skipNextScroll = false;
+          return canScroll;
         ]]></body>
       </method>
     </implementation>
@@ -64,7 +66,6 @@
         if (numberOfTabs === 1) {
           return;
         }
-        tabs._handleTabSelect(false);
       ]]></handler>
     </handlers>
   </binding>

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -596,6 +596,13 @@ VerticalTabs.prototype = {
 
     let exit = (event) => {
       if (!this.mouseInside){
+        let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
+        let scrollbox = this.document.getAnonymousElementByAttribute(arrowscrollbox, 'anonid', 'scrollbox');
+        let scrolltop = scrollbox.scrollTop;
+        arrowscrollbox.skipNextScroll = true;
+        tabs.removeAttribute('mouseInside');
+        scrollbox.scrollTop = scrolltop;
+
         if (enterTimeout > 0) {
           window.clearTimeout(enterTimeout);
           enterTimeout = -1;
@@ -615,6 +622,8 @@ VerticalTabs.prototype = {
     let enter = (event) => {
       let shouldExpand = tabs.getAttribute('mouseInside') !== 'true' &&
         leftbox.getAttribute('expanded') !== 'true';
+      let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
+      arrowscrollbox.skipNextScroll = true;
       this.mouseEntered();
       if (shouldExpand) {
         this.recordExpansion();
@@ -946,13 +955,7 @@ VerticalTabs.prototype = {
   },
 
   mouseExited: function () {
-    let tabs = this.document.getElementById('tabbrowser-tabs');
-    let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
-    let scrollbox = this.document.getAnonymousElementByAttribute(arrowscrollbox, 'anonid', 'scrollbox');
-    let scrolltop = scrollbox.scrollTop;
     this.mouseInside = false;
-    tabs.removeAttribute('mouseInside');
-    scrollbox.scrollTop = scrolltop;
 
     if (this.resizeTimeout < 0) {
       // Once the mouse exits the tab area, wait


### PR DESCRIPTION
r: @bwinton 

selected tab does not scroll into view on mouse out nor in.
selected tab does not scroll into view on resizing pinned size. (test by resizing really small)
tabs opened by ctrl-click are scrolled into view if it does not scroll off the selected tab

fixes: #730