### PR TITLE
send ping on toggle, save id per window

### DIFF
--- a/main.js
+++ b/main.js
@@ -86,6 +86,29 @@ function b64toBlob(win, b64Data, contentType, sliceSize) {
 function initWindow(window) {
   // get the XUL window that corresponds to this high-level window
   let win = viewFor(window);
+
+  win.addEventListener('TabOpen', win, false);
+  win.addEventListener('TabClose', win, false);
+  win.addEventListener('TabPinned', win, false);
+  win.addEventListener('TabUnpinned', win, false);
+
+  win.handleEvent = function (aEvent) {
+    switch (aEvent.type) {
+    case 'TabOpen':
+      utils.sendPing('tabs_created');
+      return;
+    case 'TabClose':
+      utils.sendPing('tabs_destroyed');
+      return;
+    case 'TabPinned':
+      utils.sendPing('tabs_pinned');
+      return;
+    case 'TabUnpinned':
+      utils.sendPing('tabs_unpinned');
+      return;
+    }
+  };
+
   win.VerticalTabsWindowId = VerticalTabsWindowId;
   VerticalTabsWindowId++;
 
@@ -202,6 +225,11 @@ exports.onUnload = function (reason) {
       mainWindow.removeAttribute('tabspinnedwidth');
       mainWindow.setAttribute('persist',
         mainWindow.getAttribute('persist').replace(' tabspinnned', '').replace(' tabspinnedwidth', '').replace(' toggledon', ''));
+
+      win.removeEventListener('TabOpen', win, false);
+      win.removeEventListener('TabClose', win, false);
+      win.removeEventListener('TabPinned', win, false);
+      win.removeEventListener('TabUnpinned', win, false);
       delete win.VerticalTabs;
     }
   }

--- a/main.js
+++ b/main.js
@@ -87,12 +87,14 @@ function initWindow(window) {
   // get the XUL window that corresponds to this high-level window
   let win = viewFor(window);
 
-  win.addEventListener('TabOpen', win, false);
-  win.addEventListener('TabClose', win, false);
-  win.addEventListener('TabPinned', win, false);
-  win.addEventListener('TabUnpinned', win, false);
+  win.tabCenterEventListener = {};
 
-  win.handleEvent = function (aEvent) {
+  win.addEventListener('TabOpen', win.tabCenterEventListener, false);
+  win.addEventListener('TabClose', win.tabCenterEventListener, false);
+  win.addEventListener('TabPinned', win.tabCenterEventListener, false);
+  win.addEventListener('TabUnpinned', win.tabCenterEventListener, false);
+
+  win.tabCenterEventListener.handleEvent = function (aEvent) {
     switch (aEvent.type) {
     case 'TabOpen':
       utils.sendPing('tabs_created', win);
@@ -227,10 +229,10 @@ exports.onUnload = function (reason) {
       mainWindow.setAttribute('persist',
         mainWindow.getAttribute('persist').replace(' tabspinnned', '').replace(' tabspinnedwidth', '').replace(' toggledon', ''));
 
-      win.removeEventListener('TabOpen', win, false);
-      win.removeEventListener('TabClose', win, false);
-      win.removeEventListener('TabPinned', win, false);
-      win.removeEventListener('TabUnpinned', win, false);
+      win.removeEventListener('TabOpen', win.tabCenterEventListener, false);
+      win.removeEventListener('TabClose', win.tabCenterEventListener, false);
+      win.removeEventListener('TabPinned', win.tabCenterEventListener, false);
+      win.removeEventListener('TabUnpinned', win.tabCenterEventListener, false);
       delete win.VerticalTabs;
     }
   }

--- a/main.js
+++ b/main.js
@@ -58,6 +58,7 @@ let self = require('sdk/self');
 const RESOURCE_HOST = 'tabcenter';
 
 let hotkey;
+let VerticalTabsWindowId = 1;
 
 function b64toBlob(win, b64Data, contentType, sliceSize) {
   contentType = contentType || '';
@@ -85,6 +86,8 @@ function b64toBlob(win, b64Data, contentType, sliceSize) {
 function initWindow(window) {
   // get the XUL window that corresponds to this high-level window
   let win = viewFor(window);
+  win.VerticalTabsWindowId = VerticalTabsWindowId;
+  VerticalTabsWindowId++;
 
   let data = b64toBlob(win, self.data.load('newtab.b64'), 'image/png');
 

--- a/main.js
+++ b/main.js
@@ -223,6 +223,7 @@ exports.onUnload = function (reason) {
       let mainWindow = win.document.getElementById('main-window');
       mainWindow.removeAttribute('tabspinned');
       mainWindow.removeAttribute('tabspinnedwidth');
+      mainWindow.removeAttribute('toggledon');
       mainWindow.setAttribute('persist',
         mainWindow.getAttribute('persist').replace(' tabspinnned', '').replace(' tabspinnedwidth', '').replace(' toggledon', ''));
 

--- a/main.js
+++ b/main.js
@@ -95,16 +95,16 @@ function initWindow(window) {
   win.handleEvent = function (aEvent) {
     switch (aEvent.type) {
     case 'TabOpen':
-      utils.sendPing('tabs_created');
+      utils.sendPing('tabs_created', win);
       return;
     case 'TabClose':
-      utils.sendPing('tabs_destroyed');
+      utils.sendPing('tabs_destroyed', win);
       return;
     case 'TabPinned':
-      utils.sendPing('tabs_pinned');
+      utils.sendPing('tabs_pinned', win);
       return;
     case 'TabUnpinned':
-      utils.sendPing('tabs_unpinned');
+      utils.sendPing('tabs_unpinned', win);
       return;
     }
   };

--- a/utils.js
+++ b/utils.js
@@ -59,7 +59,7 @@ const PAYLOAD_KEYS = [
   'tab_center_toggled_on'
 ];
 
-function sendPing(key) {
+function sendPing(key, window) {
   if (!PAYLOAD_KEYS.includes(key)) {
     // console.log(`Could not find ${key} in payload keys.`);
     return false;
@@ -76,7 +76,8 @@ function sendPing(key) {
     version: 1,
     tab_center_tabs_on_top: prefs.prefs.opentabstop,
     tab_center_show_thumbnails: prefs.prefs.largetabs,
-    tab_center_window_id: this.window.VerticalTabsWindowId,
+    tab_center_window_id: window.VerticalTabsWindowId,
+    tab_center_currently_toggled_on: window.document.getElementById('main-window').getAttribute('toggledon') === 'true'
   };
   payload[key] = 1;
 

--- a/utils.js
+++ b/utils.js
@@ -54,7 +54,9 @@ const PAYLOAD_KEYS = [
   'tabs_unpinned',
   'tab_center_pinned',
   'tab_center_unpinned',
-  'tab_center_expanded'
+  'tab_center_expanded',
+  'tab_center_toggled_off',
+  'tab_center_toggled_on'
 ];
 
 function sendPing(key) {
@@ -74,6 +76,7 @@ function sendPing(key) {
     version: 1,
     tab_center_tabs_on_top: prefs.prefs.opentabstop,
     tab_center_show_thumbnails: prefs.prefs.largetabs,
+    tab_center_window_id: this.window.VerticalTabsWindowId,
   };
   payload[key] = 1;
 

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -697,8 +697,6 @@ VerticalTabs.prototype = {
 
     tabs.addEventListener('TabOpen', this, false);
     tabs.addEventListener('TabClose', this, false);
-    tabs.addEventListener('TabPinned', this, false);
-    tabs.addEventListener('TabUnpinned', this, false);
     window.setTimeout(() => {
       if (mainWindow.getAttribute('tabspinned') === 'true') {
         leftbox.setAttribute('expanded', 'true');
@@ -762,8 +760,6 @@ VerticalTabs.prototype = {
       tabs.removeAttribute('width');
       tabs.removeEventListener('TabOpen', this, false);
       tabs.removeEventListener('TabClose', this, false);
-      tabs.removeEventListener('TabPinned', this, false);
-      tabs.removeEventListener('TabUnpinned', this, false);
 
       //save the first tab's label to restore after unbinding/binding
       label = tabs.firstChild.label;
@@ -991,12 +987,6 @@ VerticalTabs.prototype = {
     case 'TabClose':
       this.onTabClose(aEvent);
       return;
-    case 'TabPinned':
-      this.onTabPinned(aEvent);
-      return;
-    case 'TabUnpinned':
-      this.onTabUnpinned(aEvent);
-      return;
     case 'mouseup':
       this.onMouseUp(aEvent);
       return;
@@ -1005,21 +995,11 @@ VerticalTabs.prototype = {
 
   onTabOpen: function (aEvent) {
     let tab = aEvent.target;
-    this.sendPing('tabs_created');
     this.initTab(tab);
   },
 
   onTabClose: function (aEvent) {
     this.clearFind('tabAction');
-    this.sendPing('tabs_destroyed');
-  },
-
-  onTabPinned: function (aEvent) {
-    this.sendPing('tabs_pinned');
-  },
-
-  onTabUnpinned: function (aEvent) {
-    this.sendPing('tabs_unpinned');
   },
 };
 

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -987,9 +987,6 @@ VerticalTabs.prototype = {
     case 'TabClose':
       this.onTabClose(aEvent);
       return;
-    case 'mouseup':
-      this.onMouseUp(aEvent);
-      return;
     }
   },
 

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -95,6 +95,7 @@ VerticalTabs.prototype = {
         }
         mainWindow.setAttribute('toggledon', 'true');
         this.init();
+        window.VerticalTabs.sendPing('tab_center_toggled_on');
       };
 
       toolbar.insertBefore(sidetabsbutton, null);
@@ -541,6 +542,7 @@ VerticalTabs.prototype = {
       }
       mainWindow.setAttribute('toggledon', 'false');
       this.init();
+      window.VerticalTabs.sendPing('tab_center_toggled_off');
     };
     let sidetabsbutton = this.document.getElementById('side-tabs-button');
     if (sidetabsbutton){

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -95,7 +95,7 @@ VerticalTabs.prototype = {
         }
         mainWindow.setAttribute('toggledon', 'true');
         this.init();
-        window.VerticalTabs.sendPing('tab_center_toggled_on');
+        window.VerticalTabs.sendPing('tab_center_toggled_on', window);
       };
 
       toolbar.insertBefore(sidetabsbutton, null);
@@ -498,10 +498,10 @@ VerticalTabs.prototype = {
         let newstate = box.getAttribute('tabspinned') == 'true' ? 'false' : 'true';
         box.setAttribute('tabspinned', newstate);
         if (newstate == 'true') {
-          window.VerticalTabs.sendPing('tab_center_pinned');
+          window.VerticalTabs.sendPing('tab_center_pinned', window);
           button.setAttribute('tooltiptext', 'Shrink sidebar when not in use');
         } else {
-          window.VerticalTabs.sendPing('tab_center_unpinned');
+          window.VerticalTabs.sendPing('tab_center_unpinned', window);
           button.setAttribute('tooltiptext', 'Keep sidebar open');
           document.getElementById('verticaltabs-box').removeAttribute('search_expanded');
         }
@@ -542,7 +542,7 @@ VerticalTabs.prototype = {
       }
       mainWindow.setAttribute('toggledon', 'false');
       this.init();
-      window.VerticalTabs.sendPing('tab_center_toggled_off');
+      window.VerticalTabs.sendPing('tab_center_toggled_off', window);
     };
     let sidetabsbutton = this.document.getElementById('side-tabs-button');
     if (sidetabsbutton){
@@ -789,7 +789,7 @@ VerticalTabs.prototype = {
   },
 
   recordExpansion: function () {
-    this.sendPing('tab_center_expanded');
+    this.sendPing('tab_center_expanded', this.window);
   },
 
   adjustCrop: function () {


### PR DESCRIPTION
open for visibility

r: @bwinton 
- attach a window id to each window
- send toggle-on and off events
- send other events when toggled off (create tab, pin tab etc)

todo: 
- send current toggled state of window

questions: 
- what good does the window id do for us? It may be useful if we knew what other windows were open and their toggled states. Each ping is per-window anyway though, so currently does not serve a purpose
