### PR TITLE
fix: check for tab.label before trying to match

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -847,7 +847,7 @@ VerticalTabs.prototype = {
 
     for (let i = 0; i < this.visibleTabs.length; i++) {
       let tab = this.visibleTabs[i];
-      if (tab.label.toLowerCase().match(input_value) || this.getUri(tab).spec.toLowerCase().match(input_value)) {
+      if (tab.label && (tab.label.toLowerCase().match(input_value) || this.getUri(tab).spec.toLowerCase().match(input_value))) {
         tab.setAttribute('hidden', false);
       } else {
         hidden_counter += 1;


### PR DESCRIPTION
@bwinton 

Saw this bug on @phlsa 's machine. It is only replicate-able rarely ( I have not been able to). When clicking to toggle top tabs, nothing happens.

`tab.label is undefined, line 852` was in the console. 