### PR TITLE
fix: Theme Changes in Win and Linux

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -117,9 +117,9 @@
   list-style-image: url("resource://tabcenter/skin/glyph-new-16.svg") !important;
 }
 
-#TabsToolbar[brighttext] .tabs-newtab-button,
-#TabsToolbar[brighttext] > #new-tab-button,
-#TabsToolbar[brighttext] > toolbarpaletteitem > #new-tab-button {
+#main-window[brighttext] #TabsToolbar .tabs-newtab-button,
+#main-window[brighttext] #TabsToolbar > #new-tab-button,
+#main-window[brighttext] #TabsToolbar > toolbarpaletteitem > #new-tab-button {
   list-style-image: url("resource://tabcenter/skin/glyph-new-inverted-16.svg") !important;
 }
 
@@ -209,7 +209,7 @@
   transition: margin-left 500ms linear;
 }
 
-#verticaltabs-box[brighttext] {
+#main-window[brighttext] #verticaltabs-box {
   background-color: hsla(0, 0%, 20%, 0.98) !important;
 }
 
@@ -267,7 +267,7 @@
   -moz-box-flex: 0;
 }
 
-#verticaltabs-box #TabsToolbar[brighttext] > #top-tabs-button {
+#main-window[brighttext] #verticaltabs-box #TabsToolbar > #top-tabs-button {
   background-image: url("resource://tabcenter/skin/tc-top-white.svg") !important;
 }
 
@@ -356,11 +356,11 @@
   background-image: url("resource://tabcenter/skin/glyph-sidebar-collapse-16.svg") !important;
 }
 
-#main-window #TabsToolbar[brighttext] #pin-button {
+#main-window[brighttext] #TabsToolbar #pin-button {
   background-image: url("resource://tabcenter/skin/glyph-sidebar-expand-inverted-16.svg") !important;
 }
 
-#main-window[tabspinned="true"] #TabsToolbar[brighttext] #pin-button {
+#main-window[tabspinned="true"][brighttext] #TabsToolbar #pin-button {
   background-image: url("resource://tabcenter/skin/glyph-sidebar-collapse-inverted-16.svg") !important;
 }
 
@@ -486,7 +486,7 @@
   background-color: #ebebeb;
 }
 
-#verticaltabs-box[brighttext] #filler-tab:hover {
+#main-window[brighttext] #verticaltabs-box #filler-tab:hover {
   background-color: #3c4146 !important;
 }
 
@@ -524,7 +524,7 @@
   background-color: hsla(0, 0%, 0%, 0.05) !important;
 }
 
-#verticaltabs-box[brighttext] .tabbrowser-tab[pinned] {
+#main-window[brighttext] #verticaltabs-box .tabbrowser-tab[pinned] {
   background-color: hsla(0, 0%, 0%, 0.2) !important;
 }
 
@@ -553,7 +553,6 @@
   background-size: 12px !important;
 }
 
-#verticaltabs-box[brighttext] .tabbrowser-tab[pinned] .pinned-icon,
 #main-window[brighttext] .tabbrowser-tab[pinned] .pinned-icon {
   background-image: url("resource://tabcenter/skin/glyph-pin-pinned-inverted-12.svg") !important;
 }
@@ -574,19 +573,19 @@
 
 /* dark theme colour overrides */
 
-#verticaltabs-box[brighttext] .tabbrowser-tab {
+#main-window[brighttext] #verticaltabs-box .tabbrowser-tab {
   color: #fff !important;
 }
 
-#verticaltabs-box[brighttext] .title-wrapper .address-label {
+#main-window[brighttext] #verticaltabs-box .title-wrapper .address-label {
   color: var(--link-color-brighttext);
 }
 
-#verticaltabs-box[brighttext] .tabbrowser-tab[selected="true"] {
+#main-window[brighttext] #verticaltabs-box .tabbrowser-tab[selected="true"] {
   background-color: hsla(0, 0%, 100%, 0.1) !important;
 }
 
-#verticaltabs-box[brighttext] .tabbrowser-tab:not([selected="true"]):hover {
+#main-window[brighttext] #verticaltabs-box .tabbrowser-tab:not([selected="true"]):hover {
   background-color: hsla(0, 0%, 100%, 0.06) !important;
 }
 
@@ -628,7 +627,7 @@
   opacity: 0 !important;
 }
 
-#verticaltabs-box[brighttext] .tab-close-button {
+#main-window[brighttext] #verticaltabs-box .tab-close-button {
   background-image: url("resource://tabcenter/skin/glyph-close-inverted-16.svg") !important;
 }
 
@@ -736,7 +735,7 @@
   flex: 0 0 39px;
 }
 
-#verticaltabs-box[brighttext] #TabsToolbar {
+#main-window[brighttext] #verticaltabs-box #TabsToolbar {
   border-bottom: 1px solid hsla(0, 0%, 0%, 0.5) !important;
 }
 

--- a/skin/osx.css
+++ b/skin/osx.css
@@ -77,11 +77,6 @@
   transition-duration: 150ms !important;
 }
 
-#main-window:not([devedition-theme]) #navigator-toolbox > toolbar:not(#TabsToolbar):-moz-lwtheme {
-  background-color: transparent !important;
-  background-image: linear-gradient(hsla(0, 0%, 100%, 0), hsla(0, 0%, 100%, 0.65)) !important;
-}
-
 #navigator-toolbox > toolbar:not(#TabsToolbar):-moz-lwtheme {
   box-shadow: none !important;
 }

--- a/skin/osx.css
+++ b/skin/osx.css
@@ -46,9 +46,9 @@
     list-style-image: url("resource://tabcenter/skin/glyph-new-16.svg") !important;
   }
 
-  #TabsToolbar[brighttext] .tabs-newtab-button,
-  #TabsToolbar[brighttext] > #new-tab-button,
-  #TabsToolbar[brighttext] > toolbarpaletteitem > #new-tab-button {
+  #main-window[brighttext] #TabsToolbar .tabs-newtab-button,
+  #main-window[brighttext] #TabsToolbar > #new-tab-button,
+  #main-window[brighttext] #TabsToolbar > toolbarpaletteitem > #new-tab-button {
     list-style-image: url("resource://tabcenter/skin/glyph-new-inverted-16.svg") !important;
   }
 }

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -103,7 +103,7 @@ VerticalTabs.prototype = {
       toolbar.insertBefore(sidetabsbutton, null);
 
       (function checkbrighttext() {
-        if (toolbar.getAttribute('brighttext') === 'true') {
+        if (document.getElementById('nav-bar').getAttribute('brighttext') === 'true') {
           sidetabsbutton.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side-white.svg")', 'important');
         } else {
           sidetabsbutton.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side.svg")', 'important');
@@ -242,12 +242,11 @@ VerticalTabs.prototype = {
 
       for (let [toolbar, luminance] of luminances) {
         if (luminance <= 110) {
-          toolbar.removeAttribute('brighttext');
+          mainWindow.removeAttribute('brighttext');
         } else {
-          toolbar.setAttribute('brighttext', 'true');
+          mainWindow.setAttribute('brighttext', 'true');
         }
       }
-
     }.bind(this.window.ToolbarIconColor);
 
     this.thumbTimer = this.window.setInterval(() => {

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -248,12 +248,6 @@ VerticalTabs.prototype = {
         }
       }
 
-      if (/devedition/.test(mainWindow.style.backgroundImage)) {
-        mainWindow.setAttribute('devedition-theme', 'true');
-      } else {
-        mainWindow.removeAttribute('devedition-theme');
-      }
-
     }.bind(this.window.ToolbarIconColor);
 
     this.thumbTimer = this.window.setInterval(() => {
@@ -697,6 +691,15 @@ VerticalTabs.prototype = {
       }
     }, 150);
 
+    function checkDevTheme() {
+      if (/devedition/.test(mainWindow.style.backgroundImage)) {
+        mainWindow.setAttribute('devedition-theme', 'true');
+      } else {
+        mainWindow.removeAttribute('devedition-theme');
+      }
+    }
+    checkDevTheme();
+
     let beforeListener = function () {
       browserPanel.insertBefore(top, browserPanel.firstChild);
       top.palette = palette;
@@ -711,6 +714,7 @@ VerticalTabs.prototype = {
     let afterListener = function () {
       contentbox.insertBefore(top, contentbox.firstChild);
       top.palette = palette;
+      checkDevTheme();
       //query for and restore the urlbar value after customize mode does things....
       urlbar.value = window.gBrowser.mCurrentTab.linkedBrowser.currentURI.spec;
     };

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -215,39 +215,15 @@ VerticalTabs.prototype = {
       this.clearFind('tabGroupChange');
     });
 
-    window.ToolbarIconColor.inferFromText = function () {
-      if (!this._initialized){
-        return;
+    window.ToolbarIconColor.inferFromText = () => {
+      this.inferFromText.bind(window.ToolbarIconColor)();
+      //use default inferFromText, then set main-window[brighttext] according to the results
+      if (document.getElementById('nav-bar').getAttribute('brighttext') === 'true') {
+        mainWindow.setAttribute('brighttext', 'true');
+      } else {
+        mainWindow.removeAttribute('brighttext');
       }
-
-      function parseRGB(aColorString) {
-        let rgb = aColorString.match(/^rgba?\((\d+), (\d+), (\d+)/);
-        rgb.shift();
-        return rgb.map(x => parseInt(x));
-      }
-
-      let toolbarSelector = '#verticaltabs-box, #verticaltabs-box > toolbar:not([collapsed=true]):not(#addon-bar), #navigator-toolbox > toolbar:not([collapsed=true]):not(#addon-bar)';
-      if (platform === 'macosx') {
-        toolbarSelector += ':not([type=menubar])';
-      }
-      // The getComputedStyle calls and setting the brighttext are separated in
-      // two loops to avoid flushing layout and making it dirty repeatedly.
-
-      let luminances = new Map;
-      for (let toolbar of document.querySelectorAll(toolbarSelector)) {
-        let [r, g, b] = parseRGB(window.getComputedStyle(toolbar).color);
-        let luminance = 0.2125 * r + 0.7154 * g + 0.0721 * b;
-        luminances.set(toolbar, luminance);
-      }
-
-      for (let [toolbar, luminance] of luminances) {
-        if (luminance <= 110) {
-          mainWindow.removeAttribute('brighttext');
-        } else {
-          mainWindow.setAttribute('brighttext', 'true');
-        }
-      }
-    }.bind(this.window.ToolbarIconColor);
+    };
 
     this.thumbTimer = this.window.setInterval(() => {
       tabs.selectedItem.refreshThumbAndLabel();


### PR DESCRIPTION
@bwinton 

- when changing themes, or toggling top tabs dark theme would not activate until changing focus away from firefox.
- return the slight opacity on the toolbars, remove the gradient.

Fixes: #476 
