### PR TITLE
fix: Cleaner Animations

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -425,7 +425,6 @@
   -moz-box-flex: 0;
   -moz-box-pack: start;
   color: #000 !important;
-  transition: min-height 300ms, max-height 300ms !important;
 }
 
 .tabbrowser-tabs.large-tabs .tab-content,

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -845,7 +845,6 @@ VerticalTabs.prototype = {
     this.clearFind('tabAction');
     this.resizeTabs();
 
-    aTab.classList.add('tab-visible');
     aTab.classList.remove('tab-hidden');
 
     if (document.getElementById('tabbrowser-tabs').getAttribute('expanded') !== 'true' && document.getElementById('main-window').getAttribute('tabspinned') !== 'true') {
@@ -968,6 +967,7 @@ VerticalTabs.prototype = {
 
   onTabOpen: function (aEvent) {
     let tab = aEvent.target;
+    tab.classList.add('tab-visible');
     this.initTab(tab);
   },
 


### PR DESCRIPTION
@bwinton
tabs do not animate on togling top/bottom, nor after full screen, nor on opening new window

Fixes: #758 