### PR TITLE
Errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -228,7 +228,7 @@ exports.onUnload = function (reason) {
       mainWindow.removeAttribute('tabspinnedwidth');
       mainWindow.removeAttribute('toggledon');
       mainWindow.setAttribute('persist',
-        mainWindow.getAttribute('persist').replace(' tabspinnned', '').replace(' tabspinnedwidth', '').replace(' toggledon', ''));
+        mainWindow.getAttribute('persist').replace(' tabspinned', '').replace(' tabspinnedwidth', '').replace(' toggledon', ''));
 
       win.removeEventListener('TabOpen', win.tabCenterEventListener, false);
       win.removeEventListener('TabClose', win.tabCenterEventListener, false);

--- a/skin/base.css
+++ b/skin/base.css
@@ -688,6 +688,11 @@
   z-index: -1;
   width: 54px;
   height: 40px;
+  background: url("resource://tabcenter/skin/blank.svg");
+  background-color: #e6e6e6;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 42px 28px;
 }
 
 .tabbrowser-tabs:not(.large-tabs) .tab-meta-image html|canvas {

--- a/skin/base.css
+++ b/skin/base.css
@@ -78,7 +78,6 @@
 
 .tabbrowser-tab {
   position: relative;
-  min-width: 30px !important;
   max-width: 100% !important;
   box-shadow: 0 0 0 var(--color-blue) inset;
   pointer-events: auto !important;

--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -728,7 +728,18 @@
             ctx.drawImage(VerticalTabs.newTabImage, 0, 0);
             ctx.restore();
           } else {
-            PageThumbs.captureToCanvas(this.linkedBrowser, canvas);
+            if (this.linkedBrowser.contentWindow) {
+              let x = {};
+              try {
+                //sometimes captureToCanvas throws errors, stop them here instead
+                this.linkedBrowser.contentWindow.QueryInterface(Ci.nsIInterfaceRequestor).getInterface(Ci.nsIDOMWindowUtils).getPresShellId(x);
+                PageThumbs.captureToCanvas(this.linkedBrowser, canvas);
+              } catch (e) {
+                //sometimes we can't get the background thumb yet, ignore it.
+              }
+            } else {
+              PageThumbs.captureToCanvas(this.linkedBrowser, canvas);
+            }
           }
         ]]></body>
       </method>

--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -700,7 +700,6 @@
         const canvas = document.getAnonymousElementByAttribute(this, 'anonid', 'tab-meta-image');
         canvas.width *= window.devicePixelRatio;
         canvas.height *= window.devicePixelRatio;
-        this.refreshThumbAndLabel();
        ]]></constructor>
 
       <method name="refreshThumbAndLabel">

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -698,10 +698,12 @@ VerticalTabs.prototype = {
     };
     window.addEventListener('aftercustomization', afterListener);
 
-    window.addEventListener('resize', () => {
+    function resizeListener() {
       this.resizeTabs();
       document.documentElement.style.setProperty('--pinned-width', `${Math.min(this.pinnedWidth, document.width / 2)}px`);
-    }, false);
+    }
+    let boundResizeListener = resizeListener.bind(this);
+    window.addEventListener('resize', boundResizeListener);
     this.adjustCrop();
 
     this.unloaders.push(function () {
@@ -723,6 +725,7 @@ VerticalTabs.prototype = {
       window.removeEventListener('beforecustomization', beforeListener);
       window.removeEventListener('customizationchange', changeListener);
       window.removeEventListener('aftercustomization', afterListener);
+      window.removeEventListener('resize', boundResizeListener);
       document.removeEventListener('popuphidden', contextMenuHidden);
 
       //restore the changed menu items

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -65,6 +65,7 @@ function VerticalTabs(window, data) {
   this.window = window;
   this.document = window.document;
   this.sendPing = sendPing;
+  this.unloaders = [];
 
   window.createImageBitmap(data).then((response) => {
     this.newTabImage = response;
@@ -107,24 +108,23 @@ VerticalTabs.prototype = {
         if (e.which === 3) {
           return;
         }
-        window.removeEventListener('customizationchange', boundCheckbrighttext);
+        this.unload();
         mainWindow.setAttribute('toggledon', 'true');
         this.init();
         window.VerticalTabs.sendPing('tab_center_toggled_on', window);
       };
 
       toolbar.insertBefore(sidetabsbutton, null);
-
-      if (!this.unloaders) {
-        this.unloaders = [];
-      }
       this.unload();
+      this.unloaders.push(function () {
+        toolbar.removeChild(sidetabsbutton);
+        window.removeEventListener('customizationchange', boundCheckbrighttext);
+      });
 
       return;
     }
 
     this.window.VerticalTabs = this;
-    this.unloaders = [];
     this.resizeTimeout = -1;
     this.mouseInside = false;
 
@@ -514,10 +514,6 @@ VerticalTabs.prototype = {
       this.init();
       window.VerticalTabs.sendPing('tab_center_toggled_off', window);
     };
-    let sidetabsbutton = this.document.getElementById('side-tabs-button');
-    if (sidetabsbutton){
-      toolbar.removeChild(sidetabsbutton);
-    }
 
     leftbox.contextMenuOpen = false;
     let contextMenuHidden = (event) => {
@@ -868,6 +864,7 @@ VerticalTabs.prototype = {
     this.unloaders.forEach(function (func) {
       func.call(this);
     }, this);
+    this.unloaders = [];
 
     urlbar.value = url;
     let tabs = this.document.getElementById('tabbrowser-tabs');

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -914,10 +914,6 @@ VerticalTabs.prototype = {
   },
 
   resizeTabs: function () {
-    if (this.resizeTimeout > 0) {
-      this.window.clearTimeout(this.resizeTimeout);
-      this.resizeTimeout = -1;
-    }
     if (!this.mouseInside) {
       // If the mouse is outside the tab area,
       // resize immediately

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -799,6 +799,9 @@ VerticalTabs.prototype = {
 
   clearFind: function (purpose) {
     if (this.document.getElementById('find-input')){
+      if (this.document.getElementById('find-input').value === ''){
+        return;
+      }
       this.document.getElementById('find-input').value = '';
 
       if (purpose === 'tabGroupChange') {
@@ -850,8 +853,6 @@ VerticalTabs.prototype = {
   initTab: function (aTab) {
     let document = this.document;
     this.clearFind('tabAction');
-    this.resizeTabs();
-
     aTab.classList.remove('tab-hidden');
 
     if (document.getElementById('tabbrowser-tabs').getAttribute('expanded') !== 'true' && document.getElementById('main-window').getAttribute('tabspinned') !== 'true') {
@@ -859,8 +860,6 @@ VerticalTabs.prototype = {
     } else {
       aTab.setAttribute('crop', 'end');
     }
-
-    aTab.refreshThumbAndLabel();
   },
 
   unload: function () {

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -697,12 +697,11 @@ VerticalTabs.prototype = {
     };
     window.addEventListener('aftercustomization', afterListener);
 
-    function resizeListener() {
+    let resizeListener = () => {
       this.resizeTabs();
       document.documentElement.style.setProperty('--pinned-width', `${Math.min(this.pinnedWidth, document.width / 2)}px`);
-    }
-    let boundResizeListener = resizeListener.bind(this);
-    window.addEventListener('resize', boundResizeListener);
+    };
+    window.addEventListener('resize', resizeListener);
     this.adjustCrop();
 
     this.unloaders.push(function () {
@@ -724,7 +723,7 @@ VerticalTabs.prototype = {
       window.removeEventListener('beforecustomization', beforeListener);
       window.removeEventListener('customizationchange', changeListener);
       window.removeEventListener('aftercustomization', afterListener);
-      window.removeEventListener('resize', boundResizeListener);
+      window.removeEventListener('resize', resizeListener);
       document.removeEventListener('popuphidden', contextMenuHidden);
 
       //restore the changed menu items

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -81,13 +81,6 @@ VerticalTabs.prototype = {
     let mainWindow = document.getElementById('main-window');
     let tabs = document.getElementById('tabbrowser-tabs');
 
-    function checkbrighttext() {
-      if (document.getElementById('nav-bar').getAttribute('brighttext') === 'true') {
-        this.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side-white.svg")', 'important');
-      } else {
-        this.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side.svg")', 'important');
-      }
-    }
     if (mainWindow.getAttribute('toggledon') === 'false') {
       let toolbar = document.getElementById('TabsToolbar');
       this.clearFind();
@@ -100,9 +93,17 @@ VerticalTabs.prototype = {
       });
       sidetabsbutton.style.MozAppearance = 'none';
       sidetabsbutton.style.setProperty('-moz-image-region', 'rect(0, 16px, 16px, 0)', 'important');
-      let boundCheckbrighttext = checkbrighttext.bind(sidetabsbutton);
-      boundCheckbrighttext();
-      window.addEventListener('customizationchange', boundCheckbrighttext);
+
+      let checkBrighttext = function () {
+        if (document.getElementById('nav-bar').getAttribute('brighttext') === 'true') {
+          sidetabsbutton.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side-white.svg")', 'important');
+        } else {
+          sidetabsbutton.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side.svg")', 'important');
+        }
+      };
+      checkBrighttext();
+
+      window.addEventListener('customizationchange', checkBrighttext);
 
       sidetabsbutton.onclick = (e) => {
         if (e.which === 3) {
@@ -118,7 +119,7 @@ VerticalTabs.prototype = {
       this.unload();
       this.unloaders.push(function () {
         toolbar.removeChild(sidetabsbutton);
-        window.removeEventListener('customizationchange', boundCheckbrighttext);
+        window.removeEventListener('customizationchange', checkBrighttext);
       });
 
       return;

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -795,11 +795,12 @@ VerticalTabs.prototype = {
   },
 
   clearFind: function (purpose) {
-    if (this.document.getElementById('find-input')){
-      if (this.document.getElementById('find-input').value === ''){
+    let find_input = this.document.getElementById('find-input');
+    if (find_input){
+      if (find_input.value === ''){
         return;
       }
-      this.document.getElementById('find-input').value = '';
+      find_input.value = '';
 
       if (purpose === 'tabGroupChange') {
         //manually show pinned tabs after changing groups for the tab groups add-on, as it does not re-show them

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -106,7 +106,7 @@ VerticalTabs.prototype = {
       window.addEventListener('customizationchange', checkBrighttext);
 
       sidetabsbutton.onclick = (e) => {
-        if (e.which === 3) {
+        if (e.which !== 1) {
           return;
         }
         this.unload();
@@ -458,7 +458,7 @@ VerticalTabs.prototype = {
 
     let pin_button = this.createElement('toolbarbutton', {
       'id': 'pin-button',
-      'onclick': `if (event.which === 3) {
+      'onclick': `if (event.which !== 1) {
           return;
         }
         let box = document.getElementById('main-window');
@@ -508,7 +508,7 @@ VerticalTabs.prototype = {
       'tooltiptext': strings.topTooltip
     });
     toptabsbutton.onclick = (e) => {
-      if (e.which === 3) {
+      if (e.which !== 1) {
         return;
       }
       mainWindow.setAttribute('toggledon', 'false');

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -80,6 +80,13 @@ VerticalTabs.prototype = {
     let mainWindow = document.getElementById('main-window');
     let tabs = document.getElementById('tabbrowser-tabs');
 
+    function checkbrighttext() {
+      if (document.getElementById('nav-bar').getAttribute('brighttext') === 'true') {
+        this.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side-white.svg")', 'important');
+      } else {
+        this.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side.svg")', 'important');
+      }
+    }
     if (mainWindow.getAttribute('toggledon') === 'false') {
       let toolbar = document.getElementById('TabsToolbar');
       this.clearFind();
@@ -92,26 +99,21 @@ VerticalTabs.prototype = {
       });
       sidetabsbutton.style.MozAppearance = 'none';
       sidetabsbutton.style.setProperty('-moz-image-region', 'rect(0, 16px, 16px, 0)', 'important');
+      let boundCheckbrighttext = checkbrighttext.bind(sidetabsbutton);
+      boundCheckbrighttext();
+      window.addEventListener('customizationchange', boundCheckbrighttext);
+
       sidetabsbutton.onclick = (e) => {
         if (e.which === 3) {
           return;
         }
+        window.removeEventListener('customizationchange', boundCheckbrighttext);
         mainWindow.setAttribute('toggledon', 'true');
         this.init();
         window.VerticalTabs.sendPing('tab_center_toggled_on', window);
       };
 
       toolbar.insertBefore(sidetabsbutton, null);
-
-      (function checkbrighttext() {
-        if (document.getElementById('nav-bar').getAttribute('brighttext') === 'true') {
-          sidetabsbutton.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side-white.svg")', 'important');
-        } else {
-          sidetabsbutton.style.setProperty('list-style-image', 'url("resource://tabcenter/skin/tc-side.svg")', 'important');
-        }
-        window.addEventListener('customizationchange', checkbrighttext);
-      }());
-
 
       if (!this.unloaders) {
         this.unloaders = [];

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -893,10 +893,12 @@ VerticalTabs.prototype = {
     case 1: {
       let tabbrowser_height = tabs.clientHeight;
       let number_of_tabs = this.window.gBrowser.visibleTabs.length;
-      if (tabbrowser_height / number_of_tabs >= 58 && this.pinnedWidth > 60) {
+      if (tabbrowser_height / number_of_tabs >= 58 && this.pinnedWidth > 60 && tabs.classList.contains('large-tabs')) {
+        return;
+      } else if (tabbrowser_height / number_of_tabs >= 58 && this.pinnedWidth > 60 ){
         tabs.classList.add('large-tabs');
         this.refreshAllTabs();
-      } else {
+      } else if (tabs.classList.contains('large-tabs')){
         tabs.classList.remove('large-tabs');
       }
       return;


### PR DESCRIPTION
@bwinton 

- remove extra listeners that were missed.
- after toggle or install sometimes dark highlight only covers a portion of the tab - now it does not! 
- remove a lot of things that were calling resize many times for each tab init
- only call refreshThumbAndLabel on splitter resize **if** it is crossing the 60px threshold
- if tabs on top mode, unload the sidetabsbutton and listeners
- restore dotted line image, and capture canvas error
