### PR TITLE
fix: reversed mouse-wheel scrolling

### DIFF
--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -17,6 +17,10 @@
 
   <binding id="tabbrowser-arrowscrollbox" extends="chrome://browser/content/tabbrowser.xml#tabbrowser-arrowscrollbox">
     <implementation>
+      <field name="_isRTLScrollbox"><![CDATA[
+        document.getElementById('tabbrowser-tabs').getAttribute('opentabstop') === 'true';
+      ]]></field>
+
       <property name="_verticalTabs" onget="return this.orient == 'vertical';"/>
 
       <method name="_canScrollToElement">

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -154,21 +154,24 @@ VerticalTabs.prototype = {
     let close_next_tabs_message = document.getElementById('context_closeTabsToTheEnd');
     let previous_close_message = close_next_tabs_message.getAttribute('label');
 
-    function toggleTabsTop() {
+    function reverseTabs() {
+      let arrowscrollbox = document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
       if (prefs.opentabstop) {
         close_next_tabs_message.setAttribute('label', strings.closeTabsAbove);
         tabs.setAttribute('opentabstop', 'true');
+        arrowscrollbox._isRTLScrollbox = true;
       } else {
         close_next_tabs_message.setAttribute('label', strings.closeTabsBelow);
         tabs.removeAttribute('opentabstop');
+        arrowscrollbox._isRTLScrollbox = false;
       }
     }
 
-    toggleTabsTop();
+    reverseTabs();
 
     // update on changing preferences
     require('sdk/simple-prefs').on('opentabstop', function () {
-      toggleTabsTop();
+      reverseTabs();
     });
 
     let tabsProgressListener = {


### PR DESCRIPTION
@bwinton 

to allow wheel scrolling when tabs are reveresed, set arrowscrollbox. _isRTLScrollbox depending on opentabstop pref

fixes: #776