### PR TITLE
fix: scroll jump to top of tab list

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -706,6 +706,7 @@ VerticalTabs.prototype = {
     };
     window.addEventListener('resize', resizeListener);
     this.adjustCrop();
+    window.gBrowser.selectedTab.scrollIntoView();
 
     this.unloaders.push(function () {
       autocomplete._openAutocompletePopup = autocompleteOpen;


### PR DESCRIPTION
@bwinton 

scroll to active tab on startup, like browser default

fixes: #738.
fixes: #693.
