### PR TITLE
fix: Scroll to open tab correctly after exiting the tab column

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -576,8 +576,6 @@ VerticalTabs.prototype = {
         let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
         let scrollbox = this.document.getAnonymousElementByAttribute(arrowscrollbox, 'anonid', 'scrollbox');
         let scrolltop = scrollbox.scrollTop;
-        tabs.removeAttribute('mouseInside');
-        scrollbox.scrollTop = scrolltop;
 
         if (enterTimeout > 0) {
           window.clearTimeout(enterTimeout);
@@ -593,6 +591,9 @@ VerticalTabs.prototype = {
             tabsPopup.hidePopup();
           }
         }
+
+        tabs.removeAttribute('mouseInside');
+        scrollbox.scrollTop = scrolltop;
       }
     };
 
@@ -600,7 +601,6 @@ VerticalTabs.prototype = {
       let shouldExpand = tabs.getAttribute('mouseInside') !== 'true' &&
         leftbox.getAttribute('expanded') !== 'true';
       let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
-      this.mouseEntered();
       if (shouldExpand) {
         arrowscrollbox.skipNextScroll = true;
         this.recordExpansion();
@@ -618,6 +618,7 @@ VerticalTabs.prototype = {
           this.adjustCrop();
         }
       }
+      this.mouseEntered();
     };
 
 

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -576,7 +576,6 @@ VerticalTabs.prototype = {
         let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
         let scrollbox = this.document.getAnonymousElementByAttribute(arrowscrollbox, 'anonid', 'scrollbox');
         let scrolltop = scrollbox.scrollTop;
-        arrowscrollbox.skipNextScroll = true;
         tabs.removeAttribute('mouseInside');
         scrollbox.scrollTop = scrolltop;
 
@@ -585,6 +584,7 @@ VerticalTabs.prototype = {
           enterTimeout = -1;
         }
         if (mainWindow.getAttribute('tabspinned') !== 'true' && leftbox.getAttribute('search_expanded') !== 'true' && !leftbox.contextMenuOpen) {
+          arrowscrollbox.skipNextScroll = true;
           leftbox.removeAttribute('expanded');
           this.clearFind();
           this.adjustCrop();
@@ -600,9 +600,9 @@ VerticalTabs.prototype = {
       let shouldExpand = tabs.getAttribute('mouseInside') !== 'true' &&
         leftbox.getAttribute('expanded') !== 'true';
       let arrowscrollbox = this.document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
-      arrowscrollbox.skipNextScroll = true;
       this.mouseEntered();
       if (shouldExpand) {
+        arrowscrollbox.skipNextScroll = true;
         this.recordExpansion();
         if (event.type === 'mouseenter') {
           enterTimeout = window.setTimeout(() => {


### PR DESCRIPTION
The `skipNextScroll` workaround for #730 is only necessary when the
sidebar is set to automatically shrink, otherwise in some cases we end
up with `skipNextScroll` set to true after exiting the sidebar. This
means that the sidebar won't scroll to display the next tab opened, see
 #851 for more details.

This commit fixes this by only setting `skipNextScroll` to true if we
are in shrink mode.

Fixes #851