### PR TITLE
tour/disable buttons

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,9 +98,6 @@ function firstInstallTour(win) {
     instructions.setAttribute('id', 'tour-instructions');
     progressButton.setAttribute('id', 'tour-button');
     dismissLabel.setAttribute('id', 'tour-dismiss-label');
-    let sidetabsbuttonClick = sidetabsbutton.onclick;
-    sidetabsbutton.onclick = null;
-
     tourTitle.textContent = strings.tourTitleIntro;
     instructions.textContent = strings.tourInstructionsIntro;
     progressButton.setAttribute('label', strings.progressButtonIntro);
@@ -129,12 +126,18 @@ function firstInstallTour(win) {
       panel.hidePopup();
       outerbox.removeChild(dismissLabel);
       sidetabsbuttonClick(e);
+      let pinButton = document.getElementById('pin-button');
+      let pinButtonClick = pinButton.onclick;
+      let topTabsButton = document.getElementById('top-tabs-button');
+      let topTabsButtonClick = topTabsButton.onclick;
+      topTabsButton.onclick = null;
+      pinButton.onclick = null;
       document.getElementById('mainPopupSet').appendChild(panel); //reattach to DOM after running unload
       tourTitle.textContent = strings.tourTitleCollapse;
       instructions.textContent = strings.tourInstructionsCollapse;
       progressButton.setAttribute('label', strings.progressButtonCollapse);
       tourVideo.setAttribute('src', self.data.url('Collapse.mp4'));
-      panel.openPopup(document.getElementById('pin-button'), 'bottomcenter topleft', 0, 0, false, false);
+      panel.openPopup(pinButton, 'bottomcenter topleft', 0, 0, false, false);
 
       progressButton.onclick = (e) => {
         if (e.which !== 1) {
@@ -158,15 +161,21 @@ function firstInstallTour(win) {
           if (e.which !== 1) {
             return;
           }
+          pinButton.onclick = pinButtonClick;
+          topTabsButton.onclick = topTabsButtonClick;
           panel.hidePopup();
         };
       };
     };
 
+    let sidetabsbuttonClick = sidetabsbutton.onclick;
+    sidetabsbutton.onclick = progressButton.onclick;
+
     dismissLabel.onclick = (e) => {
       if (e.which !== 1) {
         return;
       }
+      sidetabsbutton.onclick = sidetabsbuttonClick;
       panel.hidePopup();
     };
 

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -478,7 +478,7 @@ VerticalTabs.prototype = {
       'id': 'pin-button'
     });
 
-    pin_button.addEventListener('click', function (event) {
+    pin_button.onclick = function (event) {
       if (event.which !== 1) {
         return;
       }
@@ -495,7 +495,7 @@ VerticalTabs.prototype = {
       }
       window.VerticalTabs.resizeFindInput();
       window.VerticalTabs.resizeTabs();
-    });
+    };
 
     let tooltiptext = mainWindow.getAttribute('tabspinned') === 'true' ? strings.sidebarShrink : strings.sidebarOpen;
     pin_button.setAttribute('tooltiptext', tooltiptext);


### PR DESCRIPTION
@bwinton @phlsa 

disable pinbutton and toptabsbutton during tour, enable sidetabsbutton to continue the tour

Issues when tour is running 
- clicking the pin button causes the doorhanger to lose it anchor and it will move to an unpredictable position - then slide even further left when "next" is clicked
- clicking the toptabsbutton will put all tabs on top and end tour early with no warning.

- sidetabsbutton had been disabled as it does a similar thing to toptabsbutton and ends the tour early - it is now enabled, and also continues the tour when clicked on. 

solution: 
- currently those two buttons have been disabled - though we have discussed having clicking on the focused button trigger a continuation of the tour? 

Is it more jarring to have the button do nothing, or do something unexpected?