### PR TITLE
Merge all tab resize requests in an event loop turn

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -80,7 +80,7 @@ VerticalTabs.prototype = {
     let window = this.window;
     let document = this.document;
     this.window.VerticalTabs = this;
-    this.resizeTimeout = -1;
+    this.resizeTimeout = 0;
     this.mouseInside = false;
     let mainWindow = document.getElementById('main-window');
     let tabs = document.getElementById('tabbrowser-tabs');
@@ -844,11 +844,11 @@ VerticalTabs.prototype = {
   },
 
   delayResizeTabs: function (delay) {
-    if (delay <= 0) {
+    if (delay < 0) {
       delay = 0;
     }
 
-    if (this.resizeTimeout >= 0) {
+    if (this.resizeTimeout) {
       return;
     }
 
@@ -856,9 +856,9 @@ VerticalTabs.prototype = {
   },
 
   cancelResizeTabs: function () {
-    if (this.resizeTimeout > 0) {
+    if (this.resizeTimeout) {
       this.window.clearTimeout(this.resizeTimeout);
-      this.resizeTimeout = -1;
+      this.resizeTimeout = 0;
     }
   },
 


### PR DESCRIPTION
During session restore, the tabs get resized, and hence refreshed, every time a new tab is added. This patch changes things so we always delay the resize at least until the next turn of the event loop, thus merging all requests in the current turn. For my session with ~530 tabs, that saves about 90 seconds of session restore time.