### PR TITLE
Fix compatibility with Toolbar Position Changer add-on

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -697,6 +697,7 @@ VerticalTabs.prototype = {
 
     let beforeListener = function () {
       browserPanel.insertBefore(top, browserPanel.firstChild);
+      browserPanel.insertBefore(bottom, document.getElementById('fullscreen-warning').nextSibling);
       top.palette = palette;
     };
     window.addEventListener('beforecustomization', beforeListener);
@@ -708,6 +709,7 @@ VerticalTabs.prototype = {
 
     let afterListener = function () {
       contentbox.insertBefore(top, contentbox.firstChild);
+      contentbox.appendChild(bottom);
       top.palette = palette;
       checkDevTheme();
       //query for and restore the urlbar value after customize mode does things....

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -775,7 +775,7 @@ VerticalTabs.prototype = {
 
       // Restore the tab strip.
       toolbar.insertBefore(tabs, toolbar.children[tabsIndex]);
-      toolbox.insertBefore(toolbar, navbar);
+      navbar.parentNode.insertBefore(toolbar, navbar);
       browserPanel.insertBefore(toolbox, browserPanel.firstChild);
       //remove extra #newtab-popup before they get added again in the tabs constructor
       if (NewTabButton) {


### PR DESCRIPTION
Following pull-request fixes two compatibility issues that prevented using Tab Center together with Toolbar Position Changer.

Fix 1. Use navbar parent node for insertBefore

Fixes compatibility issue with Toolbar Position Changer that enables to
move toolbars. Tab Center expects nav-bar to be child of navigation-toolbox.

This fix uses the parentNode of navbar element for determining the "real"
parent.

Fix 2.  Restore browser-bottombox location before customize

This fixes compatibility issue with Toolbar Position Changer add-on that
enables to move toolbars. TPC uses browser-bottombox as "bottom" toolbox
container for toolbars. Tab Center  moves bottombox to different location
which is not used by Firefox when entering to the Customize mode. This fix
restores the original position of bottombox in the beforeListener.

https://github.com/tumpio/toolbarpositionchanger/issues/10