### PR TITLE
feature: open tab with more info on shield from last tour panel

### DIFF
--- a/get-locale-strings.js
+++ b/get-locale-strings.js
@@ -18,6 +18,7 @@ exports.getLocaleStrings = function () {
     tourTitleCollapse: _('tour_title_collapse'),
     tourTitleRestore: _('tour_title_restore'),
     dismissLabel: _('dismiss_label'),
+    detailsLabel: _('details_label'),
     dismissLabelReminderTour: _('dismiss_label_reminder_tour'),
     tourInstructionsIntro: _('tour_instructions_intro'),
     tourInstructionsCollapse: _('tour_instructions_collapse'),

--- a/locales/en-US/addon.properties
+++ b/locales/en-US/addon.properties
@@ -24,6 +24,7 @@ tour_title_intro= Tame Your Tabs!
 tour_title_collapse= The Space You Need
 tour_title_restore= Easy In, Easy Out
 dismiss_label= Not now
+details_label= Why am I seeing this?
 dismiss_label_reminder_tour= Don’t show this again
 tour_instructions_intro= Easily work with dozens of tabs by viewing them on the side of your browser window.
 tour_instructions_collapse= Collapse the side bar to see more of the web page. Your tabs are instantly available when you move your mouse towards the edge of the window.

--- a/main.js
+++ b/main.js
@@ -106,11 +106,13 @@ function firstInstallTour(win) {
     tourVideo.setAttribute('id', 'tour-video');
 
     let dismissLabel = utils.createElement(document, 'label', {'id': 'tour-dismiss-label'});
+    let detailsLabel = utils.createElement(document, 'label', {'id': 'tour-details-label'});
 
     document.getElementById('mainPopupSet').appendChild(panel); //attach to DOM anywhere
     tourTitle.textContent = strings.tourTitleIntro;
     instructions.textContent = strings.tourInstructionsIntro;
     dismissLabel.textContent = strings.dismissLabel;
+    detailsLabel.textContent = strings.detailsLabel;
 
     if (win.reminderTour && get('extensions.tabcentertest1@mozilla.com.tourComplete')) {
       progressButton.setAttribute('label', strings.progressButtonGo);
@@ -152,6 +154,12 @@ function firstInstallTour(win) {
         utils.sendPing('tour_accepted', win, details);
         details.trigger = undefined;
 
+        let unloadTour = function () {
+          pinButton.onclick = pinButtonClick;
+          topTabsButton.onclick = topTabsButtonClick;
+          panel.hidePopup();
+        };
+
         panel.hidePopup();
         outerbox.removeChild(dismissLabel);
         sidetabsbuttonClick(e);
@@ -181,6 +189,7 @@ function firstInstallTour(win) {
             starttime = timestamp;
             movePanel(timestamp, panel, -35, 500);
             win.setTimeout(function () {
+              detailsLabel.setAttribute('visible', true);
               outerbox.style.opacity = '1';
               tourTitle.textContent = strings.tourTitleRestore;
               instructions.textContent = strings.tourInstructionsRestore;
@@ -194,9 +203,16 @@ function firstInstallTour(win) {
               return;
             }
             utils.sendPing('tour_complete', win, details);
-            pinButton.onclick = pinButtonClick;
-            topTabsButton.onclick = topTabsButtonClick;
-            panel.hidePopup();
+            unloadTour();
+          };
+          detailsLabel.onclick = (e) => {
+            if (e.which !== 1) {
+              return;
+            }
+            utils.sendPing('tour_complete_details_clicked', win, details);
+            unloadTour();
+            let tab = win.gBrowser.addTab('https://support.mozilla.org/t5/Basic-Browsing/Shield-Studies/ta-p/1361203');
+            win.gBrowser.tabContainer.selectedIndex = win.document.getElementById('tabbrowser-tabs').getIndexOfItem(tab);
           };
         };
       };
@@ -221,6 +237,7 @@ function firstInstallTour(win) {
     outerbox.appendChild(instructions);
     outerbox.appendChild(progressButton);
     outerbox.appendChild(dismissLabel);
+    outerbox.appendChild(detailsLabel);
     panel.openPopup(sidetabsbutton, 'bottomcenter topright', 0, 0, false, true);
   }
 }

--- a/skin/persistant.css
+++ b/skin/persistant.css
@@ -41,12 +41,16 @@
 #tour-button:active {
   background-color: #005bab;
 }
+#tour-details-label {
+  display: none;
+}
 
-#tour-dismiss-label {
+#tour-dismiss-label, #tour-details-label[visible] {
   margin-top: 8px;
   color: #0996f8;
   cursor: pointer;
   text-align: center;
+  display: inherit;
 }
 
 #tour-box {


### PR DESCRIPTION
Currently the page it points to is blank, but it will eventually be filled with info explaining the study.
This is only for shield and not for master.
Also, probably does not need to be translated, but to follow similar convention I added it in the same way as other strings.