### PR TITLE
Feature: shield telemetry and randomization

### DIFF
--- a/.jpmignore
+++ b/.jpmignore
@@ -12,3 +12,5 @@
 !/utils.js
 !/vertical-tabbrowser.xml
 !/verticaltabs.js
+!/node_modules/shield-studies-addon-utils/**
+!/shield-config.js

--- a/main.js
+++ b/main.js
@@ -348,18 +348,21 @@ function initWindow(window) {
     return;
   }
 
-  // if the document is loaded
-  if (isDocumentLoaded(win)) {
-    utils.installStylesheet(win, 'resource://tabcenter/skin/persistant.css');
-    addVerticalTabs(win, data);
-    firstInstallTour(win);
-  } else {
-    // Listen for load event before checking the window type
-    win.addEventListener('load', () => {
+  // Don't init VerticalTabs if it's part of the control group
+  if (get('extensions.tabcentertest1@mozilla.com.shield') !== 'control'){
+    // if the document is loaded
+    if (isDocumentLoaded(win)) {
       utils.installStylesheet(win, 'resource://tabcenter/skin/persistant.css');
       addVerticalTabs(win, data);
       firstInstallTour(win);
-    }, {once: true});
+    } else {
+      // Listen for load event before checking the window type
+      win.addEventListener('load', () => {
+        utils.installStylesheet(win, 'resource://tabcenter/skin/persistant.css');
+        addVerticalTabs(win, data);
+        firstInstallTour(win);
+      }, {once: true});
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -95,12 +95,13 @@
     "eslint-plugin-mozilla": "0.0.3",
     "glob": "^7.1.1",
     "jpm": "1.1.3",
+    "shield-studies-addon-utils": "^2.0.0",
     "stylelint": "6.7.1"
   },
   "scripts": {
     "changelog": "changelog",
     "build": "npm run locales && npm run lint && jpm xpi",
-    "test": "npm run locales && jpm run -b nightly -p Testing",
+    "test": "shield run . --debug -- -b nightly",
     "lint": "eslint . --ext=js,jsm vertical-tabbrowser.xml && stylelint \"**/*.css\"",
     "locales": "node genlocales"
   },

--- a/shield-config.js
+++ b/shield-config.js
@@ -1,0 +1,17 @@
+/* global require, exports:false */
+
+const self = require('sdk/self');
+const SHIELD_PREF = 'extensions.tabcentertest1@mozilla.com.shield';
+const {get, set} = require('sdk/preferences/service');
+let study_duration = 14; // in days
+
+const studyConfig = {
+  name: self.addonId,
+  duration: study_duration,
+  variations: {
+    'control': () => {set(SHIELD_PREF, 'control')},
+    'enabled': () => {set(SHIELD_PREF, 'enabled')}
+  }
+};
+
+exports.studyConfig = studyConfig;

--- a/skin/persistant.css
+++ b/skin/persistant.css
@@ -41,16 +41,18 @@
 #tour-button:active {
   background-color: #005bab;
 }
+
 #tour-details-label {
   display: none;
 }
 
-#tour-dismiss-label, #tour-details-label[visible] {
+#tour-dismiss-label,
+#tour-details-label[visible] {
   margin-top: 8px;
+  display: inherit;
   color: #0996f8;
   cursor: pointer;
   text-align: center;
-  display: inherit;
 }
 
 #tour-box {

--- a/utils.js
+++ b/utils.js
@@ -42,6 +42,12 @@ const {Cc, Ci} = require('chrome');
 const prefs = require('sdk/simple-prefs');
 const {get, set, reset} = require('sdk/preferences/service');
 const NS_XUL = 'http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul';
+const self = require('sdk/self');
+const {studyConfig} = require('shield-config.js');
+
+const shield = require('shield-studies-addon-utils');
+const TCStudy = new shield.Study(studyConfig);
+TCStudy.startup(self.loadReason);
 
 /* Payload */
 
@@ -89,11 +95,11 @@ function sendPing(key, window, details) {
   payload[key] = 1;
   Object.assign(payload, details);
 
-  let ping = JSON.stringify(payload);
+  // Send metrics to shield telemetry
+  TCStudy.report(payload);
+
   // console.log('send ping: ' + ping); //debug: to check the ping details
 
-  // Send metrics to the main Test Pilot add-on.
-  notifyObservers(subject, 'testpilot::send-metric', ping);
   return true;
 }
 exports.sendPing = sendPing;


### PR DESCRIPTION
Use shield cli to randomly assign control group or enabled group
- send metrics to testpilot telemetry and shield telemetry with `report`
- a little bit of css fixup to please the linter

TODO: 
- eliminate users of tabcenter and other tab related addons. 
- decide how many days the study will run for, currently set at 14