### PR TITLE
feature: cleanup after unload, excluded addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "glob": "^7.1.1",
     "jpm": "1.1.3",
     "shield-studies-addon-utils": "^2.0.0",
+    "shield-study-cli": "^1.4.0",
     "stylelint": "6.7.1"
   },
   "scripts": {

--- a/shield-config.js
+++ b/shield-config.js
@@ -1,16 +1,18 @@
 /* global require, exports:false */
 
 const self = require('sdk/self');
-const SHIELD_PREF = 'extensions.tabcentertest1@mozilla.com.shield';
 const {get, set} = require('sdk/preferences/service');
 let study_duration = 14; // in days
+
+let emptyFn = () => {};
 
 const studyConfig = {
   name: self.addonId,
   duration: study_duration,
   variations: {
-    'control': () => {set(SHIELD_PREF, 'control')},
-    'enabled': () => {set(SHIELD_PREF, 'enabled')}
+    'control': emptyFn,
+    'default': emptyFn,
+    'small-tabs': emptyFn
   }
 };
 


### PR DESCRIPTION
- unload cleanup
- small tabs and default versions
- don't install if certain add-ons are already installed.

~~@gregglind I was unable to test the shield study with an existing portfolio and so couldn't actually test the `isEligible` function. Instead I just tested the code in other places to have a sense of certainty that it would work. If you have a way of doing that please let me know.~~

I have tested `isEligible` by forcing `activeAddonIds` to contain some ids from `INCOMPATIBLE_ADDONS`. Note the function inside of `AddonManager.getAllAddons` will not run if no addons are installed, so must also remove this in order to test.


