### PR TITLE
fix: Child tabs open in correct position (reverse and pinned set).

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -368,6 +368,7 @@ VerticalTabs.prototype = {
         Services.prefs.getBoolPref('browser.tabs.insertRelatedAfterCurrent')) {
           let newTabPos = (this._lastRelatedTab || this.selectedTab)._tPos;
           this.moveTabTo(t, newTabPos);
+          this._lastRelatedTab = t;
         } else {
           this.moveTabTo(t, window.gBrowser.tabs.length - numPinned - 1);
         }


### PR DESCRIPTION
- set lastRelatedTab to be the created tab after it moves.
(turns out this was necessary)

Fixes: #996.