### PR TITLE
fix: Pinned tabs are reversed on browser restart

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,7 +71,9 @@ function reminderTour(win) {
   firstInstallTour(win);
 }
 function firstInstallTour(win) {
-  if (win.activeInstall || win.reminderTour) {
+  let document = win.document;
+  let sidetabsbutton = document.getElementById('side-tabs-button');
+  if (sidetabsbutton && (win.activeInstall || win.reminderTour)) {
     let details = {};
     if (get('extensions.tabcentertest1@mozilla.com.tourComplete')) {
       details.tour_type = 'completed_reminder';
@@ -83,8 +85,6 @@ function firstInstallTour(win) {
     utils.sendPing('tour_began', win, details);
 
     win.activeInstall = false;
-    let document = win.document;
-    let sidetabsbutton = document.getElementById('side-tabs-button');
     let panel = utils.createElement(document, 'panel', {
       'id': 'tour-panel',
       'type': 'arrow',
@@ -270,7 +270,7 @@ function setPersistantAttrs(win) {
   set('extensions.tabcentertest1@mozilla.com.lastUsedTimestamp', Date.now().toString());
 }
 
-function initWindow(window) {
+function initWindow(window, tabCenterStartup) {
   // get the XUL window that corresponds to this high-level window
   let win = viewFor(window);
 
@@ -334,13 +334,13 @@ function initWindow(window) {
   // if the document is loaded
   if (isDocumentLoaded(win)) {
     utils.installStylesheet(win, 'resource://tabcenter/skin/persistant.css');
-    addVerticalTabs(win, data);
+    addVerticalTabs(win, data, tabCenterStartup);
     firstInstallTour(win);
   } else {
     // Listen for load event before checking the window type
     win.addEventListener('load', () => {
       utils.installStylesheet(win, 'resource://tabcenter/skin/persistant.css');
-      addVerticalTabs(win, data);
+      addVerticalTabs(win, data, tabCenterStartup);
       firstInstallTour(win);
     }, {once: true});
   }
@@ -384,7 +384,9 @@ exports.main = function (options, callbacks) {
       mainWindow.setAttribute('toggledon', 'false');
       win.activeInstall = true;
     }
-    initWindow(window);
+
+    let tabCenterStartup = (options.loadReason === 'startup');
+    initWindow(window, tabCenterStartup);
   }
 
   windowWatcher.registerNotification({

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -66,7 +66,7 @@ const WAIT_BEFORE_RESIZE = 1000;
  *
  * Main entry point of this add-on.
  */
-function VerticalTabs(window, data) {
+function VerticalTabs(window, data, tabCenterStartup) {
   this.window = window;
   this.document = window.document;
   this.sendPing = sendPing;
@@ -76,11 +76,11 @@ function VerticalTabs(window, data) {
     this.newTabImage = response;
   });
 
-  this.init();
+  this.init(tabCenterStartup);
 }
 VerticalTabs.prototype = {
 
-  init: function () {
+  init: function (tabCenterStartup) {
     let window = this.window;
     let document = this.document;
     this.window.VerticalTabs = this;
@@ -388,7 +388,16 @@ VerticalTabs.prototype = {
     require('sdk/simple-prefs').on('opentabstop', reverseTabsListener);
 
     let arrowscrollbox = document.getAnonymousElementByAttribute(tabs, 'anonid', 'arrowscrollbox');
-    if (arrowscrollbox && prefs.opentabstop) {
+    if (tabCenterStartup && arrowscrollbox && prefs.opentabstop) {
+      close_next_tabs_message.setAttribute('label', strings.closeTabsAbove);
+      arrowscrollbox._isRTLScrollbox = true;
+      tabs.setAttribute('opentabstop', 'true');
+      let i = 0;
+      while (window.gBrowser.tabs[0].pinned && i <= window.gBrowser.tabs.length - 1) {
+        window.gBrowser.moveTabTo(window.gBrowser.tabs[0], window.gBrowser.tabs.length - 1);
+        i++;
+      }
+    } else if (arrowscrollbox && prefs.opentabstop) {
       window.VerticalTabs.reverseTabs(arrowscrollbox);
     } else {
       close_next_tabs_message.setAttribute('label', strings.closeTabsBelow);
@@ -1311,8 +1320,8 @@ VerticalTabs.prototype = {
   },
 };
 
-exports.addVerticalTabs = (win, data) => {
+exports.addVerticalTabs = (win, data, tabCenterStartup) => {
   if (!win.VerticalTabs) {
-    new VerticalTabs(win, data);
+    new VerticalTabs(win, data, tabCenterStartup);
   }
 };


### PR DESCRIPTION
- do not reverse pinned tabs on startup (when tabs are reversed)
- also fixed: if fresh install, but user had previously used it and left it set to tabs on side, an error is thrown when the tour cannot find it's anchor.

Fixes: #1012.