### PR TITLE
fix: Tabs are permanently destroyed when filtered and browser closes 

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -1205,6 +1205,7 @@ VerticalTabs.prototype = {
     if (tourPanel) {
       this.document.getElementById('mainPopupSet').removeChild(tourPanel);
     }
+    this.clearFind();
     let urlbar = this.document.getElementById('urlbar');
     let url = urlbar.value;
     let tabs = this.document.getElementById('tabbrowser-tabs');


### PR DESCRIPTION
Trigger clearFind before unloading to ensure all tabs are recorded properly when unloading


Fixes: https://github.com/bwinton/TabCenter/issues/1015.