### PR TITLE
fix: Tab filtering and browser restart

### DIFF
--- a/main.js
+++ b/main.js
@@ -580,6 +580,10 @@ exports.main = function (options, callbacks) {
 };
 
 exports.onUnload = function (reason) {
+  for (let window of browserWindows) {
+    viewFor(window).VerticalTabs.clearFind();
+  }
+
   // If the app is shutting down, skip the rest
   if (reason === 'shutdown') {
     return;

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -1201,7 +1201,6 @@ VerticalTabs.prototype = {
     if (tourPanel) {
       this.document.getElementById('mainPopupSet').removeChild(tourPanel);
     }
-    this.clearFind();
     let urlbar = this.document.getElementById('urlbar');
     let url = urlbar.value;
     let tabs = this.document.getElementById('tabbrowser-tabs');


### PR DESCRIPTION
clearFind on shutdown as well as uninstall/remove

Fixes #1015.