### PR TITLE
Fix: show spinners in various versions and make visible in compact themes

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -729,6 +729,10 @@
     0 0 0 1px hsla(0, 0%, 0%, 0.08);
 }
 
+#main-window[compact-theme=true] .tabbrowser-tabs.large-tabs .tab-throbber[visuallyselected=true] {
+  background-color: var(--tab-highlight-color) !important;
+}
+
 .tabbrowser-tabs.large-tabs html|canvas {
   position: absolute;
   top: 7.5px;

--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -786,6 +786,9 @@
         const canvas = document.getAnonymousElementByAttribute(this, 'anonid', 'tab-meta-image');
         canvas.width *= window.devicePixelRatio;
         canvas.height *= window.devicePixelRatio;
+        if (window.VerticalTabs.getFirefoxVersion() >= 55) {
+          document.getAnonymousNodes(this)[0].getElementsByClassName('tab-throbber')[0].removeAttribute('layer');
+        }
        ]]></constructor>
 
       <method name="refreshThumbAndLabel">

--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -39,7 +39,6 @@
 'use strict';
 
 const {Cc, Ci, Cu} = require('chrome');
-const {platform} = require('sdk/system');
 const {prefs} = require('sdk/simple-prefs');
 const {get, set} = require('sdk/preferences/service');
 
@@ -947,6 +946,12 @@ VerticalTabs.prototype = {
       }
     }, 150);
 
+    function checkCompactTheme() {
+      if(window.getComputedStyle(document.documentElement).getPropertyValue('--lwt-header-image').indexOf('browser/defaultthemes/compact') >= 0) {
+        mainWindow.setAttribute('compact-theme', true);
+      }
+    }
+
     function checkDevTheme() {
       if (/devedition/.test(mainWindow.style.backgroundImage)) {
         mainWindow.setAttribute('devedition-theme', 'true');
@@ -955,6 +960,7 @@ VerticalTabs.prototype = {
       }
     }
     checkDevTheme();
+    checkCompactTheme();
 
     let beforeListener = function () {
       browserPanel.insertBefore(top, browserPanel.firstChild);
@@ -975,6 +981,7 @@ VerticalTabs.prototype = {
       contentbox.appendChild(bottom);
       top.palette = palette;
       checkDevTheme();
+      checkCompactTheme();
       //query for and restore the urlbar value after customize mode does things....
       urlbar.value = window.gBrowser.mCurrentTab.linkedBrowser.currentURI.spec;
     };
@@ -1333,6 +1340,10 @@ VerticalTabs.prototype = {
   onCloseLastTab: function () {
     this.clearFind();
   },
+
+  getFirefoxVersion: function () {
+    return Number.parseInt(system.version);
+  }
 };
 
 exports.addVerticalTabs = (win, data, tabCenterStartup) => {


### PR DESCRIPTION
notes: using tab-highlight colour as background on active tab in compact themes - this looks a little funny, but better than not seeing anything at all. bonus, they will be fun colours if the user has containers.

in nightly, we still see the spinning box, but now also with a spinner inside.

Fixes #1038.