### PR TITLE
Note an issue with LessChrome HD

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ We are incompatible with a number of add-ons:
 - TooManyTabs
 - All-In-One Sidebar
 - Firebug
+- Mozilla Labs: Prospector - LessChrome HD
 
 Please let us know if you find any problems with extensions not mentioned.
 


### PR DESCRIPTION
Mozilla Labs: Prospector - LessChrome HD is unable to show the url bar with 'ctrl+l' or by hovering near the top of the window. The navigation bar appears to work its just hidden slightly above the screen.