### PR TITLE
fix: closing tabs on nightly leaves space and crashes

### DIFF
--- a/verticaltabs.js
+++ b/verticaltabs.js
@@ -460,6 +460,12 @@ VerticalTabs.prototype = {
       }
     });
 
+    this._removeTab = window.gBrowser.removeTab;
+    window.gBrowser.removeTab = (...args) => {
+      this._removeTab.bind(window.gBrowser)(...args);
+      window.gBrowser._endRemoveTab(args[0]);
+    };
+
     window.gBrowser._endRemoveTab = (aTab) => {
       window.gBrowser._blurTab(aTab);
       aTab.classList.add('tab-hidden');
@@ -501,6 +507,7 @@ VerticalTabs.prototype = {
       }
       this.window.gBrowser.removeTabsProgressListener(tabsProgressListener);
 
+      this.window.gBrowser.removeTab = this._removeTab;
       this.window.gBrowser.showTab = this.showTab;
       this.window.ToolbarIconColor.inferFromText = this.inferFromText;
       this.window.gBrowser._endRemoveTab = this._endRemoveTab;


### PR DESCRIPTION
ensure removeTab always calls our endRemoveTab

Fixes: #1062.