### PR TITLE
Support Firefox 56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.37 - Sunset with Version 56
+
+### Changes:
+
+* sunset after Firefox v56
+
 # v1.36 - Sunset with Version 55
 
 ### Changes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab-center",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "title": "Tab Center",
   "description": "Tab Center is an attempt to solve some of the issues that have emerged from the way people use tabs (most notably the “too many tabs” problem) and provide a more versatile UI basis for future innovation. The first version of this Firefox add-on arranges tabs in a vertical rather than horizontal fashion. It is heavily inspired by and borrows ideas from the excellent VerticalTabs add-on.",
   "locales": {
@@ -118,7 +118,7 @@
     "doc": "docs"
   },
   "engines": {
-    "firefox": ">=51.* || <=55.*"
+    "firefox": ">=51.* || <=56.*"
   },
   "icon": "resource://tabcenter/skin/icon.png",
   "id": "tabcentertest1@mozilla.com",


### PR DESCRIPTION
My Nightly just upgraded to version 56 and Tab Center stopped working.

I lost my vertical tabs and my productivity suffered. Tab Center
appeared to work just fine with yesterday's Nightly. So it should
still work with Nightly 56.

According to issue #1102, a replacement doesn't yet appear to be ready.
And Tab Center is still being advertised at
https://testpilot.firefox.com/experiments/tab-center/. So it seems
prudent to still support Tab Center with Firefox 56 so users aren't
annoyed.